### PR TITLE
Add signals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         }
     ],
     "require": {
-        "spatie/laravel-model-states": "^2.1"
+        "spatie/laravel-model-states": "^2.1",
+        "react/promise": "^2.9"
     },
     "require-dev": {
         "orchestra/testbench": "^7.1"

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -5,6 +5,7 @@ namespace Workflow;
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -5,6 +5,7 @@ namespace Workflow;
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -13,7 +14,7 @@ use Throwable;
 use Workflow\Middleware\WorkflowMiddleware;
 use Workflow\Models\StoredWorkflow;
 
-class Activity implements ShouldBeEncrypted, ShouldQueue
+class Activity implements ShouldBeEncrypted, ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     
@@ -32,6 +33,11 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         $this->index = $index;
         $this->model = $model;
         $this->arguments = $arguments;
+    }
+
+    public function uniqueId()
+    {
+        return $this->model->id;
     }
 
     public function handle()

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -5,7 +5,6 @@ namespace Workflow;
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -28,4 +28,9 @@ class StoredWorkflow extends Model
     {
         return $this->hasMany(StoredWorkflowLog::class);
     }
+
+    public function signals()
+    {
+        return $this->hasMany(StoredWorkflowSignal::class);
+    }
 }

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Workflow\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StoredWorkflowSignal extends Model
+{
+    protected $table = 'workflow_signals';
+
+    protected $guarded = [];
+
+    public function workflow()
+    {
+        return $this->belongsTo(StoredWorkflow::class);
+    }
+}

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Workflow;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Workflow\Models\StoredWorkflow;
+
+class Signal implements ShouldBeEncrypted, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    
+    public $tries = 3;
+
+    public $maxExceptions = 3;
+
+    public $model;
+
+    public function __construct(StoredWorkflow $model)
+    {
+        $this->model = $model;
+    }
+
+    public function handle()
+    {
+        $workflow = $this->model->toWorkflow();
+
+        if ($workflow->running()) {
+            try {
+                $workflow->resume();
+            } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
+                $this->release();
+            }
+        }
+    }
+}

--- a/src/SignalMethod.php
+++ b/src/SignalMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Workflow;
+
+use Spiral\Attributes\NamedArgumentConstructorAttribute;
+
+final class SignalMethod implements NamedArgumentConstructorAttribute
+{
+}

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -63,7 +63,6 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
         $this->coroutine = $this->execute(...$this->arguments);
 
         while ($this->coroutine->valid()) {
-            $previousLog = $log;
             $nextLog = $this->model->logs()->whereIndex($this->index + 1)->first();
 
             $this->model
@@ -71,8 +70,8 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
                 ->when($nextLog, function($query, $nextLog) {
                     $query->where('created_at', '<=', $nextLog->created_at);
                 })
-                ->when($previousLog, function($query, $previousLog) {
-                    $query->where('created_at', '>', $previousLog->created_at);
+                ->when($log, function($query, $log) {
+                    $query->where('created_at', '>', $log->created_at);
                 })
                 ->each(function ($signal) {
                     $this->{$signal->method}(...unserialize($signal->arguments));

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -146,7 +146,7 @@ class WorkflowStub
                 'arguments' => serialize($arguments),
             ]);
 
-            while (true) {
+            while ($this->running()) {
                 try {
                     $this->fresh()->dispatch();
                     break;

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -145,14 +145,7 @@ class WorkflowStub
                 'arguments' => serialize($arguments),
             ]);
 
-            while ($this->running()) {
-                try {
-                    $this->fresh()->dispatch();
-                    break;
-                } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound $th) {
-                    usleep(1000);
-                }
-            }
+            Signal::dispatch($this->model);
         }
     }
 }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -2,15 +2,19 @@
 
 namespace Workflow;
 
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use ReflectionClass;
 use Workflow\Models\StoredWorkflow;
-
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\States\WorkflowPendingStatus;
+use function React\Promise\resolve;
 
 class WorkflowStub
 {
     protected $model;
+    protected $await;
 
     private function __construct($model)
     {
@@ -36,6 +40,19 @@ class WorkflowStub
         return new static($model);
     }
 
+    public static function await($condition): PromiseInterface
+    {
+        $result = $condition();
+
+        if ($result === true) {
+            return resolve(true);
+        }
+
+        $deferred = new Deferred();
+
+        return $deferred->promise();
+    }
+
     public function id()
     {
         return $this->model->id;
@@ -48,7 +65,7 @@ class WorkflowStub
 
     public function running()
     {
-        return ! in_array($this->status(), [
+        return !in_array($this->status(), [
             WorkflowCompletedStatus::class,
             WorkflowFailedStatus::class,
         ]);
@@ -109,5 +126,34 @@ class WorkflowStub
         $this->model->status->transitionTo(WorkflowPendingStatus::class);
 
         $this->model->class::dispatch($this->model, ...unserialize($this->model->arguments));
+    }
+
+    public function __call($method, $arguments)
+    {
+        if (collect((new ReflectionClass($this->model->class))->getMethods())
+            ->filter(function ($method) {
+                return collect($method->getAttributes())
+                    ->contains(function ($attribute) {
+                        return $attribute->getName() === SignalMethod::class;
+                    });
+            })
+            ->map(function ($method) {
+                return $method->getName();
+            })->contains($method)
+        ) {
+            $this->model->signals()->create([
+                'method' => $method,
+                'arguments' => serialize($arguments),
+            ]);
+
+            while (true) {
+                try {
+                    $this->fresh()->dispatch();
+                    break;
+                } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound $th) {
+                    usleep(1000);
+                }
+            }
+        }
     }
 }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -14,7 +14,6 @@ use function React\Promise\resolve;
 class WorkflowStub
 {
     protected $model;
-    protected $await;
 
     private function __construct($model)
     {

--- a/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
+++ b/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWorkflowSignalsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('workflow_signals', function (Blueprint $table) {
+            $table->id('id');
+            $table->foreignId('stored_workflow_id')->index();
+            $table->text('method');
+            $table->text('arguments')->nullable();
+            $table->timestamps();
+
+            $table->index(['stored_workflow_id', 'created_at']);
+
+            $table->foreign('stored_workflow_id')->references('id')->on('workflows')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('workflow_signals');
+    }
+}

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -18,6 +18,24 @@ class WorkflowTest extends TestCase
 
         $workflow->start();
 
+        $workflow->cancel();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+    }
+
+    public function testCompletedDelay()
+    {
+        $workflow = WorkflowStub::make(TestWorkflow::class);
+
+        $workflow->start(false, true);
+
+        sleep(5);
+
+        $workflow->cancel();
+
         while ($workflow->running());
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
@@ -48,6 +66,8 @@ class WorkflowTest extends TestCase
         $this->assertStringContainsString('TestFailingActivity', $workflow->output());
 
         $workflow->fresh()->start();
+
+        $workflow->cancel();
 
         while ($workflow->running());
 

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -3,15 +3,44 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-
+use Tests\TestSimpleWorkflow;
 use Tests\TestWorkflow;
-use Workflow\Exceptions\WorkflowFailedException;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
 
 class WorkflowTest extends TestCase
 {
+    public function testSimple()
+    {
+        $workflow = WorkflowStub::make(TestSimpleWorkflow::class);
+
+        $workflow->start();
+
+        $workflow->cancel();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+
+    public function testSimpleDelay()
+    {
+        $workflow = WorkflowStub::make(TestSimpleWorkflow::class);
+
+        $workflow->start();
+
+        sleep(5);
+
+        $workflow->cancel();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+
     public function testCompleted()
     {
         $workflow = WorkflowStub::make(TestWorkflow::class);

--- a/tests/TestSimpleWorkflow.php
+++ b/tests/TestSimpleWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests;
+
+use Workflow\SignalMethod;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class TestSimpleWorkflow extends Workflow
+{
+    private bool $canceled = false;
+
+    #[SignalMethod]
+    public function cancel()
+    {
+        $this->canceled = true;
+    }
+
+    public function execute()
+    {
+        yield WorkflowStub::await(fn () => $this->canceled);
+
+        return 'workflow';
+    }
+}

--- a/tests/TestWorkflow.php
+++ b/tests/TestWorkflow.php
@@ -3,19 +3,37 @@
 namespace Tests;
 
 use Workflow\ActivityStub;
+use Workflow\SignalMethod;
 use Workflow\Workflow;
+use Workflow\WorkflowStub;
 
 class TestWorkflow extends Workflow
 {
-    public function execute($shouldFail = false)
+    private bool $canceled;
+
+    #[SignalMethod]
+    public function cancel()
     {
+        $this->canceled = true;
+    }
+
+    public function execute($shouldFail = false, $shouldAssert = false)
+    {
+        $this->canceled = false;
+
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+        if ($shouldAssert) {
+            assert($this->canceled === false);
+        }
 
         if ($shouldFail) {
             $result = yield ActivityStub::make(TestFailingActivity::class);
         } else {
             $result = yield ActivityStub::make(TestActivity::class);
         }
+
+        yield WorkflowStub::await(fn () => $this->canceled);
 
         return 'workflow_' . $result . '_' . $otherResult;
     }

--- a/tests/TestWorkflow.php
+++ b/tests/TestWorkflow.php
@@ -9,7 +9,7 @@ use Workflow\WorkflowStub;
 
 class TestWorkflow extends Workflow
 {
-    private bool $canceled;
+    private bool $canceled = false;
 
     #[SignalMethod]
     public function cancel()
@@ -19,8 +19,6 @@ class TestWorkflow extends Workflow
 
     public function execute($shouldFail = false, $shouldAssert = false)
     {
-        $this->canceled = false;
-
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
         if ($shouldAssert) {

--- a/tests/TestWorkflow.php
+++ b/tests/TestWorkflow.php
@@ -19,11 +19,13 @@ class TestWorkflow extends Workflow
 
     public function execute($shouldFail = false, $shouldAssert = false)
     {
+        if ($shouldAssert)
+            assert($this->canceled === false);
+
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
-        if ($shouldAssert) {
+        if ($shouldAssert)
             assert($this->canceled === false);
-        }
 
         if ($shouldFail) {
             $result = yield ActivityStub::make(TestFailingActivity::class);


### PR DESCRIPTION
This PR adds the ability to await on a condition and signal a workflow.

For example:

```
class TestWorkflow extends Workflow
{
    private bool $canceled = false;

    #[SignalMethod]
    public function cancel()
    {
        $this->canceled = true;
    }

    public function execute()
    {
        yield WorkflowStub::await(fn () => $this->canceled);

        return;
    }
}
```

This workflow will reach the `await()` call and then pause until some external code signals the workflow like this:

```
$workflow->cancel();
```


