### PR TITLE
Add timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ The workflow will reach the call to `WorkflowStub::await()` and then hibernate u
 $workflow->ready();
 ```
 
+## Timers
+
+Using `WorkflowStub::timer($seconds)` allows a workflow to wait for a fixed amount of time in seconds.
+
+```
+class MyWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $result = yield ActivityStub::make(MyActivity::class);
+
+        yield WorkflowStub::timer(300);
+
+        $otherResult = yield ActivityStub::make(MyOtherActivity::class);
+
+        return $result . $otherResult;
+    }
+}
+```
+
+The workflow will reach the call to `WorkflowStub::timer()` and then hibernate for 5 minutes. After that time has passed, it will continute execution.
+
 ## Failed Workflows
 
 If a workflow fails or crashes at any point then it can be resumed from that point. Any activities that were successfully completed during the previous execution of the workflow will not be ran again.

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -33,4 +33,9 @@ class StoredWorkflow extends Model
     {
         return $this->hasMany(StoredWorkflowSignal::class);
     }
+
+    public function timers()
+    {
+        return $this->hasMany(StoredWorkflowTimer::class);
+    }
 }

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Workflow\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StoredWorkflowTimer extends Model
+{
+    protected $table = 'workflow_timers';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'stop_at' => 'datetime',
+    ];
+
+    public function workflow()
+    {
+        return $this->belongsTo(StoredWorkflow::class);
+    }
+}

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -82,7 +82,7 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
                     $this->{$signal->method}(...unserialize($signal->arguments));
                 });
 
-            WorkflowStub::setContext((object) [
+            WorkflowStub::setContext([
                 'model' => $this->model,
                 'index' => $this->index,
             ]);

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -60,6 +60,11 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
                 $this->{$signal->method}(...unserialize($signal->arguments));
             });
 
+        WorkflowStub::setContext([
+            'model' => $this->model,
+            'index' => $this->index,
+        ]);
+
         $this->coroutine = $this->execute(...$this->arguments);
 
         while ($this->coroutine->valid()) {
@@ -76,6 +81,11 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
                 ->each(function ($signal) {
                     $this->{$signal->method}(...unserialize($signal->arguments));
                 });
+
+            WorkflowStub::setContext((object) [
+                'model' => $this->model,
+                'index' => $this->index,
+            ]);
 
             $current = $this->coroutine->current();
 

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -76,19 +76,19 @@ class WorkflowStub
         if (is_null($timer)) {
             $when = now()->addSeconds($seconds);
 
-            $context->model->timers()->create([
+            $timer = $context->model->timers()->create([
                 'index' => $context->index,
                 'stop_at' => $when,
             ]);
-
-            Signal::dispatch($context->model)->delay($when);
         } else {
-            $result = $timer->stop_at->isBefore(now()->addSeconds($seconds));
+            $result = $timer->stop_at->lessThanOrEqualTo(now()->addSeconds($seconds));
 
             if ($result === true) {
                 return resolve(true);
             }
         }
+
+        Signal::dispatch($context->model)->delay($timer->stop_at);
 
         $deferred = new Deferred();
 

--- a/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
+++ b/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWorkflowTimersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('workflow_timers', function (Blueprint $table) {
+            $table->id('id');
+            $table->foreignId('stored_workflow_id')->index();
+            $table->integer('index')->nullable();
+            $table->timestamp('stop_at');
+            $table->timestamps();
+
+            $table->index(['stored_workflow_id', 'created_at']);
+
+            $table->foreign('stored_workflow_id')->references('id')->on('workflows')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('workflow_timers');
+    }
+}

--- a/tests/Feature/TimerWorkflowTest.php
+++ b/tests/Feature/TimerWorkflowTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestTimerWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+class TimerWorkflowTest extends TestCase
+{
+    public function testTimerWorkflow()
+    {
+        $workflow = WorkflowStub::make(TestTimerWorkflow::class);
+
+        $now = now();
+
+        $workflow->start(0);
+
+        while ($workflow->running());
+
+        $this->assertLessThan(5, now()->diffInSeconds($now));
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+
+    public function testTimerWorkflowDelay()
+    {
+        $workflow = WorkflowStub::make(TestTimerWorkflow::class);
+
+        $now = now();
+
+        $workflow->start(5);
+
+        while ($workflow->running());
+
+        $this->assertGreaterThan(5, now()->diffInSeconds($now));
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+}

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Tests\TestSimpleWorkflow;
-use Tests\TestWorkflow;
+use Tests\Fixtures\TestSimpleWorkflow;
+use Tests\Fixtures\TestWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Fixtures/TestActivity.php
+++ b/tests/Fixtures/TestActivity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fixtures;
 
 use Workflow\Activity;
 

--- a/tests/Fixtures/TestFailingActivity.php
+++ b/tests/Fixtures/TestFailingActivity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fixtures;
 
 use Exception;
 use Workflow\Activity;

--- a/tests/Fixtures/TestOtherActivity.php
+++ b/tests/Fixtures/TestOtherActivity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fixtures;
 
 use Workflow\Activity;
 

--- a/tests/Fixtures/TestSimpleWorkflow.php
+++ b/tests/Fixtures/TestSimpleWorkflow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fixtures;
 
 use Workflow\SignalMethod;
 use Workflow\Workflow;

--- a/tests/Fixtures/TestTimerWorkflow.php
+++ b/tests/Fixtures/TestTimerWorkflow.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class TestTimerWorkflow extends Workflow
+{
+    public function execute($seconds = 1)
+    {
+        yield WorkflowStub::timer($seconds);
+
+        return 'workflow';
+    }
+}

--- a/tests/Fixtures/TestWorkflow.php
+++ b/tests/Fixtures/TestWorkflow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fixtures;
 
 use Workflow\ActivityStub;
 use Workflow\SignalMethod;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,13 +14,13 @@ abstract class TestCase extends BaseTestCase
     {
         Dotenv::createImmutable(__DIR__.'/..')->safeLoad();
 
-        // self::$process = new Process(['php', 'artisan', 'queue:work']);
-        // self::$process->start();
+        self::$process = new Process(['php', 'artisan', 'queue:work']);
+        self::$process->start();
     }
 
     public static function tearDownAfterClass(): void
     {
-        // self::$process->stop();
+        self::$process->stop();
     }
 
     protected function defineDatabaseMigrations()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,13 +14,13 @@ abstract class TestCase extends BaseTestCase
     {
         Dotenv::createImmutable(__DIR__.'/..')->safeLoad();
 
-        self::$process = new Process(['php', 'artisan', 'queue:work']);
-        self::$process->start();
+        // self::$process = new Process(['php', 'artisan', 'queue:work']);
+        // self::$process->start();
     }
 
     public static function tearDownAfterClass(): void
     {
-        self::$process->stop();
+        // self::$process->stop();
     }
 
     protected function defineDatabaseMigrations()


### PR DESCRIPTION
This PR adds the ability to create a timer and allow a workflow to pause execution for a fixed amount of time. This uses [delayed dispatching](https://laravel.com/docs/9.x/queues#delayed-dispatching) under the hood. Therefore, there is nothing actually running while a timer is active.

For example the following workflow will pause for 5 minutes and then complete:

```
class TestWorkflow extends Workflow
{
    public function execute()
    {
        yield WorkflowStub::timer(300);

        return;
    }
}
```

I will eventually make these timers cancelable.