### PR TITLE
Add awaitWithTimeout

### DIFF
--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -97,7 +97,7 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
 
                     $this->model->logs()->create([
                         'index' => $this->index,
-                        'result' => serialize(true),
+                        'result' => serialize($value),
                     ]);
 
                     $log = $this->model->logs()->whereIndex($this->index)->first();

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -64,6 +64,17 @@ class WorkflowStub
         return $deferred->promise();
     }
 
+    public static function awaitWithTimeout($seconds, $condition): PromiseInterface
+    {
+        $result = $condition();
+
+        if ($result === true) {
+            return resolve(true);
+        }
+
+        return self::timer($seconds)->then(fn ($completed) => !$completed);
+    }
+
     public static function timer($seconds): PromiseInterface
     {
         if ($seconds <= 0)

--- a/tests/Feature/AwaitWithTimeoutWorkflowTest.php
+++ b/tests/Feature/AwaitWithTimeoutWorkflowTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestAwaitWithTimeoutWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+class AwaitWithTimeoutWorkflowTest extends TestCase
+{
+    public function testCompleted()
+    {
+        $workflow = WorkflowStub::make(TestAwaitWithTimeoutWorkflow::class);
+
+        $now = now();
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertLessThan(5, now()->diffInSeconds($now));
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+
+    public function testTimedout()
+    {
+        $workflow = WorkflowStub::make(TestAwaitWithTimeoutWorkflow::class);
+
+        $now = now();
+
+        $workflow->start(true);
+
+        while ($workflow->running());
+
+        $this->assertGreaterThan(5, now()->diffInSeconds($now));
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_timed_out', $workflow->output());
+    }
+}

--- a/tests/Fixtures/TestAwaitWithTimeoutWorkflow.php
+++ b/tests/Fixtures/TestAwaitWithTimeoutWorkflow.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class TestAwaitWithTimeoutWorkflow extends Workflow
+{
+    public function execute($shouldTimeout = false)
+    {
+        $result = yield WorkflowStub::awaitWithTimeout(5, fn () => !$shouldTimeout);
+
+        return $result ? 'workflow' : 'workflow_timed_out';
+    }
+}


### PR DESCRIPTION
This PR adds the ability to await on a signal or the completion of a timer. If the timer completes first then `yield WorkflowStub::awaitWithTimeout()` returns `false` otherwise it returns `true`.