### PR TITLE
Add backoff

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -17,10 +17,10 @@ use Workflow\Models\StoredWorkflow;
 class Activity implements ShouldBeEncrypted, ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-    
-    public $tries = 3;
 
-    public $maxExceptions = 3;
+    public $tries = PHP_INT_MAX;
+
+    public $maxExceptions = PHP_INT_MAX;
 
     public $arguments;
 
@@ -33,6 +33,11 @@ class Activity implements ShouldBeEncrypted, ShouldQueue, ShouldBeUnique
         $this->index = $index;
         $this->model = $model;
         $this->arguments = $arguments;
+    }
+
+    public function backoff()
+    {
+        return [1, 2, 5, 10, 15, 30, 60, 120];
     }
 
     public function uniqueId()

--- a/src/Middleware/WorkflowMiddleware.php
+++ b/src/Middleware/WorkflowMiddleware.php
@@ -8,6 +8,12 @@ class WorkflowMiddleware
     {
         $result = $next($job);
 
-        $job->model->toWorkflow()->next($job->index, $result);
+        try {
+            $job->model->toWorkflow()->next($job->index, $result);
+        } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
+            if ($job->model->toWorkflow()->running()) {
+                $job->release();
+            }
+        }
     }
 }

--- a/src/States/WorkflowStatus.php
+++ b/src/States/WorkflowStatus.php
@@ -13,6 +13,7 @@ abstract class WorkflowStatus extends State
             ->default(WorkflowCreatedStatus::class)
             ->allowTransition(WorkflowCreatedStatus::class, WorkflowPendingStatus::class)
             ->allowTransition(WorkflowFailedStatus::class, WorkflowPendingStatus::class)
+            ->allowTransition(WorkflowPendingStatus::class, WorkflowFailedStatus::class)
             ->allowTransition(WorkflowPendingStatus::class, WorkflowRunningStatus::class)
             ->allowTransition(WorkflowRunningStatus::class, WorkflowCompletedStatus::class)
             ->allowTransition(WorkflowRunningStatus::class, WorkflowFailedStatus::class)

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -19,9 +19,9 @@ abstract class Workflow implements ShouldBeEncrypted, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $tries = 3;
+    public $tries = 1;
 
-    public $maxExceptions = 3;
+    public $maxExceptions = 1;
 
     public $arguments;
 

--- a/tests/Feature/AwaitWithTimeoutWorkflowTest.php
+++ b/tests/Feature/AwaitWithTimeoutWorkflowTest.php
@@ -15,7 +15,7 @@ class AwaitWithTimeoutWorkflowTest extends TestCase
 
         $now = now();
 
-        $workflow->start();
+        $workflow->start(shouldTimeout: false);
 
         while ($workflow->running());
 
@@ -30,7 +30,7 @@ class AwaitWithTimeoutWorkflowTest extends TestCase
 
         $now = now();
 
-        $workflow->start(true);
+        $workflow->start(shouldTimeout: true);
 
         while ($workflow->running());
 

--- a/tests/Feature/AwaitWorkflowTest.php
+++ b/tests/Feature/AwaitWorkflowTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestAwaitWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+class AwaitWorkflowTest extends TestCase
+{
+    public function testCompleted()
+    {
+        $workflow = WorkflowStub::make(TestAwaitWorkflow::class);
+
+        $workflow->start();
+
+        $workflow->cancel();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+
+    public function testCompletedWithDelay()
+    {
+        $workflow = WorkflowStub::make(TestAwaitWorkflow::class);
+
+        $workflow->start();
+
+        sleep(5);
+
+        $workflow->cancel();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow', $workflow->output());
+    }
+}

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestExceptionWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+class ExceptionWorkflowTest extends TestCase
+{
+    public function testRetry()
+    {
+        $workflow = WorkflowStub::make(TestExceptionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+    }
+}

--- a/tests/Feature/FailingWorkflowTest.php
+++ b/tests/Feature/FailingWorkflowTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestFailingWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\States\WorkflowFailedStatus;
+use Workflow\WorkflowStub;
+
+class FailingWorkflowTest extends TestCase
+{
+    public function testRetry()
+    {
+        $workflow = WorkflowStub::make(TestFailingWorkflow::class);
+
+        $workflow->start(shouldFail: true);
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
+        $this->assertStringContainsString('failed', $workflow->output());
+
+        $workflow->fresh()->start(shouldFail: false);
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+    }
+}

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Tests\Fixtures\TestFailingWorkflow;
 use Tests\Fixtures\TestSimpleWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
@@ -11,41 +12,11 @@ use Workflow\WorkflowStub;
 
 class WorkflowTest extends TestCase
 {
-    public function testSimple()
-    {
-        $workflow = WorkflowStub::make(TestSimpleWorkflow::class);
-
-        $workflow->start();
-
-        $workflow->cancel();
-
-        while ($workflow->running());
-
-        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
-        $this->assertSame('workflow', $workflow->output());
-    }
-
-    public function testSimpleDelay()
-    {
-        $workflow = WorkflowStub::make(TestSimpleWorkflow::class);
-
-        $workflow->start();
-
-        sleep(5);
-
-        $workflow->cancel();
-
-        while ($workflow->running());
-
-        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
-        $this->assertSame('workflow', $workflow->output());
-    }
-
     public function testCompleted()
     {
         $workflow = WorkflowStub::make(TestWorkflow::class);
 
-        $workflow->start();
+        $workflow->start(shouldAssert: false);
 
         $workflow->cancel();
 
@@ -59,42 +30,9 @@ class WorkflowTest extends TestCase
     {
         $workflow = WorkflowStub::make(TestWorkflow::class);
 
-        $workflow->start(false, true);
+        $workflow->start(shouldAssert: true);
 
         sleep(5);
-
-        $workflow->cancel();
-
-        while ($workflow->running());
-
-        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
-        $this->assertSame('workflow_activity_other', $workflow->output());
-    }
-
-    public function testFailed()
-    {
-        $workflow = WorkflowStub::make(TestWorkflow::class);
-
-        $workflow->start(true);
-
-        while ($workflow->running());
-
-        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
-        $this->assertStringContainsString('TestFailingActivity', $workflow->output());
-    }
-
-    public function testRecoveredFailed()
-    {
-        $workflow = WorkflowStub::make(TestWorkflow::class);
-
-        $workflow->start(true);
-
-        while ($workflow->running());
-
-        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
-        $this->assertStringContainsString('TestFailingActivity', $workflow->output());
-
-        $workflow->fresh()->start();
 
         $workflow->cancel();
 

--- a/tests/Fixtures/TestAwaitWorkflow.php
+++ b/tests/Fixtures/TestAwaitWorkflow.php
@@ -16,7 +16,7 @@ class TestAwaitWorkflow extends Workflow
         $this->canceled = true;
     }
 
-    public function execute($shouldTimeout = false)
+    public function execute()
     {
         yield WorkflowStub::await(fn () => $this->canceled);
 

--- a/tests/Fixtures/TestAwaitWorkflow.php
+++ b/tests/Fixtures/TestAwaitWorkflow.php
@@ -6,7 +6,7 @@ use Workflow\SignalMethod;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
 
-class TestSimpleWorkflow extends Workflow
+class TestAwaitWorkflow extends Workflow
 {
     private bool $canceled = false;
 
@@ -16,7 +16,7 @@ class TestSimpleWorkflow extends Workflow
         $this->canceled = true;
     }
 
-    public function execute()
+    public function execute($shouldTimeout = false)
     {
         yield WorkflowStub::await(fn () => $this->canceled);
 

--- a/tests/Fixtures/TestExceptionActivity.php
+++ b/tests/Fixtures/TestExceptionActivity.php
@@ -2,14 +2,15 @@
 
 namespace Tests\Fixtures;
 
+use Exception;
 use Workflow\Activity;
 
-class TestFailingActivity extends Activity
+class TestExceptionActivity extends Activity
 {
     public function execute()
     {
         if ($this->attempts() === 1) {
-            $this->model->toWorkflow()->fail('failed');
+            throw new Exception('failed');
         }
 
         return 'activity';

--- a/tests/Fixtures/TestExceptionWorkflow.php
+++ b/tests/Fixtures/TestExceptionWorkflow.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+class TestExceptionWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+        $result = yield ActivityStub::make(TestExceptionActivity::class);
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}

--- a/tests/Fixtures/TestFailingWorkflow.php
+++ b/tests/Fixtures/TestFailingWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+class TestFailingWorkflow extends Workflow
+{
+    public function execute($shouldFail = false)
+    {
+        $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+        if ($shouldFail) {
+            $result = yield ActivityStub::make(TestFailingActivity::class);
+        } else {
+            $result = yield ActivityStub::make(TestActivity::class);
+        }
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}

--- a/tests/Fixtures/TestWorkflow.php
+++ b/tests/Fixtures/TestWorkflow.php
@@ -17,7 +17,7 @@ class TestWorkflow extends Workflow
         $this->canceled = true;
     }
 
-    public function execute($shouldFail = false, $shouldAssert = false)
+    public function execute($shouldAssert = false)
     {
         if ($shouldAssert)
             assert($this->canceled === false);
@@ -27,11 +27,7 @@ class TestWorkflow extends Workflow
         if ($shouldAssert)
             assert($this->canceled === false);
 
-        if ($shouldFail) {
-            $result = yield ActivityStub::make(TestFailingActivity::class);
-        } else {
-            $result = yield ActivityStub::make(TestActivity::class);
-        }
+        $result = yield ActivityStub::make(TestActivity::class);
 
         yield WorkflowStub::await(fn () => $this->canceled);
 


### PR DESCRIPTION
This PR updates the default workflow and activity retry policies. It also sets a backoff policy for activities. Workflows are now only tried once and activities are retried forever. This allows for the pattern of a failing activity to continue to be retried until it is fixed via either some transient condition resolving itself or via a manual intervention such as a code deploy or database change. The tests have also been refactored for some cleanup and readability.