### PR TITLE
Add heartbeats

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -22,6 +22,8 @@ class Activity implements ShouldBeEncrypted, ShouldQueue, ShouldBeUnique
 
     public $maxExceptions = PHP_INT_MAX;
 
+    public $timeout = 0;
+
     public $arguments;
 
     public $index;
@@ -62,5 +64,12 @@ class Activity implements ShouldBeEncrypted, ShouldQueue, ShouldBeUnique
     public function failed(Throwable $exception)
     {
         $this->model->toWorkflow()->fail($exception);
+    }
+
+    public function heartbeat()
+    {
+        pcntl_alarm(
+            max($this->timeout, 0)
+        );
     }
 }

--- a/tests/Feature/HeartbeatWorkflowTest.php
+++ b/tests/Feature/HeartbeatWorkflowTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Tests\Fixtures\TestHeartbeatWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+class HeartbeatWorkflowTest extends TestCase
+{
+    public function testHeartbeat()
+    {
+        $workflow = WorkflowStub::make(TestHeartbeatWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+    }
+}

--- a/tests/Fixtures/TestHeartbeatActivity.php
+++ b/tests/Fixtures/TestHeartbeatActivity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+class TestHeartbeatActivity extends Activity
+{
+    public $timeout = 5;
+
+    public function execute()
+    {
+        for ($i = 0; $i < 10; $i++) { 
+            sleep(1);
+            $this->heartbeat();
+        }
+
+        return 'activity';
+    }
+}

--- a/tests/Fixtures/TestHeartbeatWorkflow.php
+++ b/tests/Fixtures/TestHeartbeatWorkflow.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+class TestHeartbeatWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+        $result = yield ActivityStub::make(TestHeartbeatActivity::class);
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}


### PR DESCRIPTION
This PR adds the ability to heartbeat an activity so that it doesn't get killed for being frozen.

```
class TestHeartbeatActivity extends Activity
{
    public $timeout = 5;

    public function execute()
    {
        for ($i = 0; $i < 10; $i++) { 
            sleep(1);
            $this->heartbeat();
        }

        return 'activity';
    }
}
```