### PR TITLE
Microsecond timestamps

### DIFF
--- a/src/Middleware/WorkflowMiddleware.php
+++ b/src/Middleware/WorkflowMiddleware.php
@@ -12,7 +12,7 @@ final class WorkflowMiddleware
 
         try {
             $job->storedWorkflow->toWorkflow()
-                ->next($job->index, $result);
+                ->next($job->index, $job::class, $result);
         } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
             if ($job->storedWorkflow->toWorkflow()->running()) {
                 $job->release();

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\WorkflowStub;
@@ -29,6 +30,26 @@ final class StoredWorkflow extends Model
     protected $casts = [
         'status' => WorkflowStatus::class,
     ];
+
+    public function getCreatedAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setCreatedAtAttribute(Carbon $value): void
+    {
+        $this->attributes['created_at'] = $value->format('Y-m-d H:i:s.u');
+    }
+
+    public function getUpdatedAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setUpdatedAtAttribute(Carbon $value): void
+    {
+        $this->attributes['updated_at'] = now()->format('Y-m-d H:i:s.u');
+    }
 
     public function toWorkflow()
     {

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 final class StoredWorkflowLog extends Model
 {
+    public const UPDATED_AT = null;
+
     /**
      * @var string
      */
@@ -17,6 +20,16 @@ final class StoredWorkflowLog extends Model
      * @var mixed[]
      */
     protected $guarded = [];
+
+    public function getCreatedAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setCreatedAtAttribute(Carbon $value): void
+    {
+        $this->attributes['created_at'] = $value->format('Y-m-d H:i:s.u');
+    }
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 final class StoredWorkflowSignal extends Model
 {
+    public const UPDATED_AT = null;
+
     /**
      * @var string
      */
@@ -17,6 +20,16 @@ final class StoredWorkflowSignal extends Model
      * @var mixed[]
      */
     protected $guarded = [];
+
+    public function getCreatedAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setCreatedAtAttribute(Carbon $value): void
+    {
+        $this->attributes['created_at'] = $value->format('Y-m-d H:i:s.u');
+    }
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 final class StoredWorkflowTimer extends Model
 {
+    public const UPDATED_AT = null;
+
     /**
      * @var string
      */
@@ -24,6 +27,26 @@ final class StoredWorkflowTimer extends Model
     protected $casts = [
         'stop_at' => 'datetime',
     ];
+
+    public function getCreatedAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setCreatedAtAttribute(Carbon $value): void
+    {
+        $this->attributes['created_at'] = $value->format('Y-m-d H:i:s.u');
+    }
+
+    public function getStopAtAttribute(string $value): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+    }
+
+    public function setStopAtAttribute(Carbon $value): void
+    {
+        $this->attributes['stop_at'] = $value->format('Y-m-d H:i:s.u');
+    }
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -104,6 +104,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                     $this->storedWorkflow->logs()
                         ->create([
                             'index' => $this->index,
+                            'class' => Signal::class,
                             'result' => serialize($value),
                         ]);
 

--- a/src/migrations/2022_01_01_000000_create_workflows_table.php
+++ b/src/migrations/2022_01_01_000000_create_workflows_table.php
@@ -22,7 +22,7 @@ final class CreateWorkflowsTable extends Migration
                 ->nullable();
             $blueprint->string('status')
                 ->default('pending');
-            $blueprint->timestamps();
+            $blueprint->timestamps(6);
         });
     }
 

--- a/src/migrations/2022_01_01_000001_create_workflow_logs_table.php
+++ b/src/migrations/2022_01_01_000001_create_workflow_logs_table.php
@@ -17,12 +17,12 @@ final class CreateWorkflowLogsTable extends Migration
             $blueprint->id('id');
             $blueprint->foreignId('stored_workflow_id')
                 ->index();
-            $blueprint->integer('index')
-                ->nullable();
+            $blueprint->unsignedBigInteger('index');
+            $blueprint->text('class');
             $blueprint->text('result')
                 ->nullable();
-            $blueprint->timestamps();
-            $blueprint->index(['stored_workflow_id', 'index']);
+            $blueprint->timestamp('created_at', 6);
+            $blueprint->unique(['stored_workflow_id', 'index']);
             $blueprint->foreign('stored_workflow_id')
                 ->references('id')
                 ->on('workflows')

--- a/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
+++ b/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
@@ -20,7 +20,7 @@ final class CreateWorkflowSignalsTable extends Migration
             $blueprint->text('method');
             $blueprint->text('arguments')
                 ->nullable();
-            $blueprint->timestamps();
+            $blueprint->timestamp('created_at', 6);
             $blueprint->index(['stored_workflow_id', 'created_at']);
             $blueprint->foreign('stored_workflow_id')
                 ->references('id')

--- a/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
+++ b/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
@@ -17,10 +17,9 @@ final class CreateWorkflowTimersTable extends Migration
             $blueprint->id('id');
             $blueprint->foreignId('stored_workflow_id')
                 ->index();
-            $blueprint->integer('index')
-                ->nullable();
-            $blueprint->timestamp('stop_at');
-            $blueprint->timestamps();
+            $blueprint->integer('index');
+            $blueprint->timestamp('stop_at', 6);
+            $blueprint->timestamp('created_at', 6);
             $blueprint->index(['stored_workflow_id', 'created_at']);
             $blueprint->foreign('stored_workflow_id')
                 ->references('id')

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
@@ -23,6 +26,9 @@ final class WorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestOtherActivity::class, TestActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->toArray());
     }
 
     public function testCompletedDelay(): void
@@ -39,5 +45,8 @@ final class WorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestOtherActivity::class, TestActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->toArray());
     }
 }


### PR DESCRIPTION
By default, Laravel timestamps only have second precision. This PR changes them to microseconds for the stored workflows. Migration updates will be done in place until this is at least out of alpha.