### PR TITLE
Add parallel activities

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -10,9 +10,9 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Throwable;
+use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Middleware\WorkflowMiddleware;
 use Workflow\Models\StoredWorkflow;
 
@@ -78,7 +78,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     {
 
         return [
-            (new WithoutOverlapping("workflow:{$this->storedWorkflow->id}"))->shared(),
+            new WithoutOverlappingMiddleware($this->storedWorkflow->id, WithoutOverlappingMiddleware::ACTIVITY),
             new WorkflowMiddleware(),
         ];
     }

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -36,7 +36,7 @@ final class ActivityStub
         if ($log) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            return resolve($log->result);
+            return resolve(unserialize($log->result));
         } else {
             $current = new self($activity, ...$arguments);
 

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use function React\Promise\all;
+use function React\Promise\resolve;
+
 final class ActivityStub
 {
     private $arguments;
@@ -15,9 +20,40 @@ final class ActivityStub
         $this->arguments = $arguments;
     }
 
-    public static function make($activity, ...$arguments): static
+    public static function all(iterable $promises): PromiseInterface
     {
-        return new self($activity, ...$arguments);
+        return all([...$promises]);
+    }
+
+    public static function make($activity, ...$arguments): PromiseInterface
+    {
+        $context = WorkflowStub::getContext();
+
+        $log = $context->storedWorkflow->logs()
+            ->whereIndex($context->index)
+            ->first();
+
+        if ($log) {
+            ++$context->index;
+            WorkflowStub::setContext($context);
+            return resolve($log->result);
+        } else {
+            $current = new self($activity, ...$arguments);
+
+            $current->activity()::dispatch(
+                $context->index,
+                $context->now,
+                $context->storedWorkflow,
+                ...$current->arguments()
+            );
+
+            ++$context->index;
+            WorkflowStub::setContext($context);
+
+            $deferred = new Deferred();
+
+            return $deferred->promise();
+        }
     }
 
     public function activity()

--- a/src/Middleware/WithoutOverlappingMiddleware.php
+++ b/src/Middleware/WithoutOverlappingMiddleware.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\InteractsWithTime;
+
+class WithoutOverlappingMiddleware
+{
+    use InteractsWithTime;
+
+    public const WORKFLOW = 1;
+    public const ACTIVITY = 2;
+
+    public string $key;
+
+    public int $type;
+
+    public $releaseAfter;
+
+    public $expiresAfter;
+
+    public $prefix = 'laravel-workflow-overlap:';
+
+    public function __construct($workflowId, $type, $releaseAfter = 0, $expiresAfter = 0)
+    {
+        $this->key = "{$workflowId}";
+        $this->type = $type;
+        $this->releaseAfter = $releaseAfter;
+        $this->expiresAfter = $this->secondsUntil($expiresAfter);
+    }
+
+    public function handle($job, $next)
+    {
+        $cache = Container::getInstance()->make(Cache::class);
+        $workflowSemaphore = (int) $cache->get($this->getWorkflowSemaphoreKey(), 0);
+        $activitySemaphore = (int) $cache->get($this->getActivitySemaphoreKey(), 0);
+
+        switch ($this->type) {
+            case self::WORKFLOW:
+                $locked = false;
+                if ($workflowSemaphore === 0 && $activitySemaphore === 0) {
+                    $locked = $this->compareAndSet($cache, $this->getWorkflowSemaphoreKey(), $workflowSemaphore, $workflowSemaphore + 1);
+                }
+                break;
+
+            case self::ACTIVITY:
+                $locked = false;
+                if ($workflowSemaphore === 0) {
+                    $locked = $this->compareAndSet($cache, $this->getActivitySemaphoreKey(), $activitySemaphore, $activitySemaphore + 1);
+                }
+                break;
+
+            default:
+                $locked = false;
+                break;
+        }
+
+        if ($locked) {
+            try {
+                $next($job);
+            } finally {
+                switch ($this->type) {
+                    case self::WORKFLOW:
+                        $unlocked = false;
+                        while (! $unlocked) {
+                            $workflowSemaphore = (int) $cache->get($this->getWorkflowSemaphoreKey());
+                            $unlocked = $this->compareAndSet($cache, $this->getWorkflowSemaphoreKey(), $workflowSemaphore, max($workflowSemaphore - 1, 0));
+                        }
+                        break;
+        
+                    case self::ACTIVITY:
+                        $unlocked = false;
+                        while (! $unlocked) {
+                            $activitySemaphore = (int) $cache->get($this->getActivitySemaphoreKey());
+                            $unlocked = $this->compareAndSet($cache, $this->getActivitySemaphoreKey(), $activitySemaphore, max($activitySemaphore - 1, 0));
+                        }
+                        break;
+                }        
+            }
+        } elseif (! is_null($this->releaseAfter)) {
+            $job->release($this->releaseAfter);
+        }
+    }
+
+    public function getLockKey()
+    {
+        return $this->prefix.$this->key;
+    }
+
+    public function getWorkflowSemaphoreKey()
+    {
+        return $this->getLockKey().':workflow';
+    }
+
+    public function getActivitySemaphoreKey()
+    {
+        return $this->getLockKey().':activity';
+    }
+
+    private function compareAndSet($cache, $key, $expectedValue, $newValue)
+    {
+        $lock = $cache->lock($this->getLockKey(), $this->expiresAfter);
+    
+        if ($lock->get()) {
+            try {
+                $currentValue = (int) $cache->get($key, null);
+    
+                if ($currentValue == $expectedValue) {
+                    $cache->put($key, (int) $newValue);
+                    return true;
+                }
+            } finally {
+                $lock->release();
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -9,9 +9,8 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
+use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 
 final class Signal implements ShouldBeEncrypted, ShouldQueue
@@ -33,7 +32,7 @@ final class Signal implements ShouldBeEncrypted, ShouldQueue
     public function middleware()
     {
         return [
-            (new WithoutOverlapping("workflow:{$this->storedWorkflow->id}"))->shared(),
+            new WithoutOverlappingMiddleware($this->storedWorkflow->id, WithoutOverlappingMiddleware::WORKFLOW),
         ];
     }
 

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Workflow;
 
 use BadMethodCallException;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
 use React\Promise\PromiseInterface;
 use Throwable;
+use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowRunningStatus;
@@ -49,7 +50,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
     public function middleware()
     {
         return [
-            (new WithoutOverlapping("workflow:{$this->storedWorkflow->id}"))->shared(),
+            new WithoutOverlappingMiddleware($this->storedWorkflow->id, WithoutOverlappingMiddleware::WORKFLOW),
         ];
     }
 
@@ -132,22 +133,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
                 $current->then(function ($value) use (&$resolved): void {
                     $resolved = true;
-
-                    $log = $this->storedWorkflow->logs()
-                        ->whereIndex($this->index)
-                        ->first();
-
-                    if (! $log) {
-                        $log = $this->storedWorkflow->logs()
-                            ->create([
-                                'index' => $this->index,
-                                'now' => $this->now,
-                                'class' => Signal::class,
-                                'result' => serialize($value),
-                            ]);
-                    }
-
-                    $this->coroutine->send(unserialize($log->result));
+                    $this->coroutine->send($value);
                 });
 
                 if (! $resolved) {
@@ -156,27 +142,10 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                     return;
                 }
             } else {
-                $log = $this->storedWorkflow->logs()
-                    ->whereIndex($this->index)
-                    ->first();
-
-                if ($log) {
-                    $this->coroutine->send(unserialize($log->result));
-                } else {
-                    $this->storedWorkflow->status->transitionTo(WorkflowWaitingStatus::class);
-
-                    $current->activity()::dispatch(
-                        $this->index,
-                        $this->now,
-                        $this->storedWorkflow,
-                        ...$current->arguments()
-                    );
-
-                    return;
-                }
+                throw new Exception('something went wrong');
             }
 
-            ++$this->index;
+            $this->index = WorkflowStub::getContext()->index;
         }
 
         $this->storedWorkflow->output = serialize($this->coroutine->getReturn());

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -102,6 +102,8 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
         $this->coroutine = $this->{'execute'}(...$this->arguments);
 
         while ($this->coroutine->valid()) {
+            $this->index = WorkflowStub::getContext()->index;
+
             $nextLog = $this->storedWorkflow->logs()
                 ->whereIndex($this->index + 1)
                 ->first();
@@ -144,8 +146,6 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             } else {
                 throw new Exception('something went wrong');
             }
-
-            $this->index = WorkflowStub::getContext()->index;
         }
 
         $this->storedWorkflow->output = serialize($this->coroutine->getReturn());

--- a/tests/Feature/ConcurrentWorkflowTest.php
+++ b/tests/Feature/ConcurrentWorkflowTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\TestOtherActivity;
+use Tests\Fixtures\TestConcurrentWorkflow;
+use Tests\TestCase;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+final class ConcurrentWorkflowTest extends TestCase
+{
+    public function testCompleted(): void
+    {
+        $workflow = WorkflowStub::make(TestConcurrentWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestOtherActivity::class, TestActivity::class], $workflow->logs()
+            ->pluck('class')
+            ->toArray());
+    }
+}

--- a/tests/Fixtures/TestConcurrentWorkflow.php
+++ b/tests/Fixtures/TestConcurrentWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+final class TestConcurrentWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $otherResultPromise = ActivityStub::make(TestOtherActivity::class, 'other');
+
+        $resultPromise = ActivityStub::make(TestActivity::class);
+
+        $results = yield ActivityStub::all([$otherResultPromise, $resultPromise]);
+
+        return 'workflow_' . $results[1] . '_' . $results[0];
+    }
+}


### PR DESCRIPTION
This PR adds a new middleware that was partially written by ChatGPT. The built-in Laravel middleware `WithoutOverlapping` wouldn't support the ability for parallel activities so I wrote one with the help of ChatGPT.

Here's an example of how you would use it:

```
$promise1 = ActivityStub::make(MyActivity::class);
$promise2 = ActivityStub::make(MyActivity::class);

yield ActivityStub::all([$promise1, $promise2]);
```

This is still a work in progress...