### PR TITLE
Use config to specify stored workflow models

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -9,7 +9,7 @@ use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\WorkflowStub;
 
-final class StoredWorkflow extends Model
+class StoredWorkflow extends Model
 {
     use HasStates;
 

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -39,21 +39,21 @@ final class StoredWorkflow extends Model
 
     public function logs(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(StoredWorkflowLog::class);
+        return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class));
     }
 
     public function signals(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(StoredWorkflowSignal::class);
+        return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class));
     }
 
     public function timers(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(StoredWorkflowTimer::class);
+        return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class));
     }
 
     public function exceptions(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(StoredWorkflowException::class);
+        return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class));
     }
 }

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -6,7 +6,7 @@ namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-final class StoredWorkflowException extends Model
+class StoredWorkflowException extends Model
 {
     public const UPDATED_AT = null;
 

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -24,6 +24,6 @@ final class StoredWorkflowException extends Model
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(StoredWorkflow::class);
+        return $this->belongsTo(config('workflows.stored_workflow_model', StoredWorkflow::class));
     }
 }

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -31,6 +31,6 @@ final class StoredWorkflowLog extends Model
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(StoredWorkflow::class);
+        return $this->belongsTo(config('workflows.stored_workflow_model', StoredWorkflow::class));
     }
 }

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -6,7 +6,7 @@ namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-final class StoredWorkflowLog extends Model
+class StoredWorkflowLog extends Model
 {
     public const UPDATED_AT = null;
 

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -24,6 +24,6 @@ final class StoredWorkflowSignal extends Model
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(StoredWorkflow::class);
+        return $this->belongsTo(config('workflows.stored_workflow_model', StoredWorkflow::class));
     }
 }

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -6,7 +6,7 @@ namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-final class StoredWorkflowSignal extends Model
+class StoredWorkflowSignal extends Model
 {
     public const UPDATED_AT = null;
 

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -31,6 +31,6 @@ final class StoredWorkflowTimer extends Model
 
     public function workflow(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(StoredWorkflow::class);
+        return $this->belongsTo(config('workflows.stored_workflow_model', StoredWorkflow::class));
     }
 }

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -6,7 +6,7 @@ namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-final class StoredWorkflowTimer extends Model
+class StoredWorkflowTimer extends Model
 {
     public const UPDATED_AT = null;
 

--- a/src/Providers/WorkflowServiceProvider.php
+++ b/src/Providers/WorkflowServiceProvider.php
@@ -11,7 +11,7 @@ final class WorkflowServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishes([
-            __DIR__ . '/../config/' => config_path('/config'),
+            __DIR__ . '/../config/workflows.php' => config_path('workflows.php'),
         ], 'config');
 
         $this->publishes([

--- a/src/Providers/WorkflowServiceProvider.php
+++ b/src/Providers/WorkflowServiceProvider.php
@@ -11,6 +11,10 @@ final class WorkflowServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishes([
+            __DIR__ . '/../config/' => config_path('/config'),
+        ], 'config');
+
+        $this->publishes([
             __DIR__ . '/../migrations/' => database_path('/migrations'),
         ], 'migrations');
     }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -56,7 +56,7 @@ final class WorkflowStub
 
     public static function make($class): static
     {
-        $storedWorkflow = StoredWorkflow::create([
+        $storedWorkflow = config('workflows.stored_workflow_model', StoredWorkflow::class)::create([
             'class' => $class,
         ]);
 
@@ -65,7 +65,7 @@ final class WorkflowStub
 
     public static function load($id)
     {
-        return static::fromStoredWorkflow(StoredWorkflow::findOrFail($id));
+        return static::fromStoredWorkflow(config('workflows.stored_workflow_model', StoredWorkflow::class)::findOrFail($id));
     }
 
     public static function fromStoredWorkflow(StoredWorkflow $storedWorkflow): static

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    'stored_workflow_model' => Workflow\Models\StoredWorkflow::class,
+
+    'stored_workflow_exception_model' => Workflow\Models\StoredWorkflowException::class,
+
+    'stored_workflow_log_model' => Workflow\Models\StoredWorkflowLog::class,
+
+    'stored_workflow_signal_model' => Workflow\Models\StoredWorkflowSignal::class,
+
+    'stored_workflow_timer_model' => Workflow\Models\StoredWorkflowTimer::class,
+
+];


### PR DESCRIPTION
This pull request updates the `StoredWorkflow`, `StoredWorkflowException`, `StoredWorkflowLog`, and `StoredWorkflowSignal` classes to use the values returned by `config('workflows.stored_workflow_model')`, `config('workflows.stored_workflow_exception_model')`, `config('workflows.stored_workflow_log_model')`, and `config('workflows.stored_workflow_signal_model')`, respectively, rather than hardcoding the class names. This allows developers to specify their own custom classes that extend these classes and customize their behavior. The main reason would be to customize the `$connection` options.