### PR TITLE
Add sagas

### DIFF
--- a/src/Traits/Sagas.php
+++ b/src/Traits/Sagas.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Traits;
+
+use Workflow\ActivityStub;
+
+trait Sagas
+{
+    private array $compensations = [];
+
+    private bool $parallelCompensation = false;
+
+    private bool $continueWithError = false;
+
+    public function setParallelCompensation(bool $parallelCompensation): self
+    {
+        $this->parallelCompensation = $parallelCompensation;
+
+        return $this;
+    }
+
+    public function setContinueWithError(bool $continueWithError): self
+    {
+        $this->continueWithError = $continueWithError;
+
+        return $this;
+    }
+
+    public function addCompensation(callable $compensation): self
+    {
+        $this->compensations[] = $compensation;
+
+        return $this;
+    }
+
+    public function compensate()
+    {
+        if ($this->parallelCompensation) {
+            $compensations = [];
+            foreach ($this->compensations as $compensation) {
+                $compensations[] = $compensation();
+            }
+            yield ActivityStub::all($compensations);
+        } else {
+            foreach ($this->compensations as $compensation) {
+                yield $compensation();
+            }
+        }
+    }
+}

--- a/src/Traits/Sagas.php
+++ b/src/Traits/Sagas.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow\Traits;
 
+use Throwable;
 use Workflow\ActivityStub;
 
 trait Sagas
@@ -45,7 +46,13 @@ trait Sagas
             yield ActivityStub::all($compensations);
         } else {
             foreach ($this->compensations as $compensation) {
-                yield $compensation();
+                try {
+                    yield $compensation();
+                } catch (Throwable $th) {
+                    if (! $this->continueWithError) {
+                        throw $th;
+                    }
+                }
             }
         }
     }

--- a/tests/Feature/SagaWorkflowTest.php
+++ b/tests/Feature/SagaWorkflowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\TestSagaWorkflow;
+use Tests\Fixtures\TestUndoActivity;
+use Tests\TestCase;
+use Workflow\Exception;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\States\WorkflowFailedStatus;
+use Workflow\WorkflowStub;
+
+final class SagaWorkflowTest extends TestCase
+{
+    public function testCompleted(): void
+    {
+        $workflow = WorkflowStub::make(TestSagaWorkflow::class);
+
+        $workflow->start(shouldThrow: false);
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('saga_workflow', $workflow->output());
+        $this->assertSame([TestActivity::class, TestUndoActivity::class, Exception::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+
+    public function testFailed(): void
+    {
+        $workflow = WorkflowStub::make(TestSagaWorkflow::class);
+
+        $workflow->start(shouldThrow: true);
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
+        $this->assertNull($workflow->output());
+        $this->assertSame([TestActivity::class, TestUndoActivity::class, Exception::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+}

--- a/tests/Fixtures/TestSagaActivity.php
+++ b/tests/Fixtures/TestSagaActivity.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Exception;
+use Workflow\Activity;
+
+final class TestSagaActivity extends Activity
+{
+    public $tries = 1;
+
+    public function execute()
+    {
+        throw new Exception('saga');
+    }
+}

--- a/tests/Fixtures/TestSagaUndoActivity.php
+++ b/tests/Fixtures/TestSagaUndoActivity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestSagaUndoActivity extends Activity
+{
+    public function execute()
+    {
+        return 'saga_undo_activity';
+    }
+}

--- a/tests/Fixtures/TestSagaWorkflow.php
+++ b/tests/Fixtures/TestSagaWorkflow.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+class TestSagaWorkflow extends Workflow
+{
+    public function execute($shouldThrow = false)
+    {
+        try {
+            yield ActivityStub::make(TestActivity::class);
+            $this->addCompensation(static fn () => ActivityStub::make(TestUndoActivity::class));
+
+            yield ActivityStub::make(TestSagaActivity::class);
+            $this->addCompensation(static fn () => ActivityStub::make(TestSagaUndoActivity::class));
+        } catch (\Throwable $th) {
+            yield from $this->compensate();
+            if ($shouldThrow) {
+                throw $th;
+            }
+        }
+
+        return 'saga_workflow';
+    }
+}

--- a/tests/Fixtures/TestUndoActivity.php
+++ b/tests/Fixtures/TestUndoActivity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+class TestUndoActivity extends Activity
+{
+    public function execute()
+    {
+        return 'undo_activity';
+    }
+}

--- a/tests/Unit/Traits/SagasTest.php
+++ b/tests/Unit/Traits/SagasTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Traits;
+
+use Exception;
+use Tests\Fixtures\TestWorkflow;
+use Tests\TestCase;
+use Workflow\Models\StoredWorkflow;
+use Workflow\WorkflowStub;
+
+final class SagasTest extends TestCase
+{
+    public function testCompensation(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $job = new ($storedWorkflow->class)($storedWorkflow, []);
+        $job->addCompensation(static fn () => true);
+        $this->assertSame([true], iterator_to_array($job->compensate()));
+    }
+
+    public function testCompensationWithError(): void
+    {
+        $this->expectException(Exception::class);
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $job = new ($storedWorkflow->class)($storedWorkflow, []);
+        $job->addCompensation(static fn () => throw new Exception('error'));
+        $this->assertSame([true], iterator_to_array($job->compensate()));
+    }
+
+    public function testCompensationContinueWithError(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $job = new ($storedWorkflow->class)($storedWorkflow, []);
+        $job->addCompensation(static fn () => throw new Exception('error'));
+        $job->setContinueWithError(true);
+        $this->assertSame([], iterator_to_array($job->compensate()));
+    }
+
+    public function testParallelCompensation(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $job = new ($storedWorkflow->class)($storedWorkflow, []);
+        $job->addCompensation(static fn () => true);
+        $job->setParallelCompensation(true);
+        iterator_to_array($job->compensate())[0]
+            ->then(fn ($result) => $this->assertSame([true], $result));
+    }
+}


### PR DESCRIPTION
This adds a built-in [saga pattern ](https://microservices.io/patterns/data/saga.html). Consider the following workflow. If `SimpleOtherActivity` fails and runs out of retries then `SimpleActivity` will not be rolled back.

```php
class SimpleWorkflow extends Workflow
{
    public function execute()
    {
        yield ActivityStub::make(SimpleActivity::class);

        yield ActivityStub::make(SimpleOtherActivity::class, 'other');

        return 'workflow';
    }
}
```

Here's the same workflow using sagas. If `SimpleActivity` is successful but `SimpleOtherActivity` fails and runs out of retries then it will throw an exception which will in turn call the compensating `SimpleUndoActivity` activity.

```php
class SimpleWorkflow extends Workflow
{
    public function execute()
    {
        try {
            yield ActivityStub::make(SimpleActivity::class);
            $this->addCompensation(fn () => ActivityStub::make(SimpleUndoActivity::class));

            yield ActivityStub::make(SimpleOtherActivity::class, 'other');
            $this->addCompensation(fn () => ActivityStub::make(SimpleUndoOtherActivity::class, 'other'));
        } catch (\Throwable $th) {
            yield from $this->compensate();
            throw $th;
        }

        return 'workflow';
    }
}
```