### PR TITLE
Check for the activity connection and use dispatchNow on sync queue

### DIFF
--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -12,6 +12,7 @@ use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Throwable;
 use Workflow\Serializers\Y;
+use ReflectionClass;
 
 final class ActivityStub
 {


### PR DESCRIPTION
First of all very nice repository i've been working on a project which aims to do the same thing.
Although mine is not as complete as yours, yours is very well done! 
If you're interested see: https://github.com/florisbosch/laravel-multi-stage-batch

This code change checks for the activity connection and utilizes dispatchNow on the sync queue if the connection is set to "sync". It then creates logs for the stored workflow and updates the context accordingly. In case the connection is not "sync," the code falls back to using dispatch. The context and index are incremented, and the Deferred class is used to return a promise.

This pull request which might be useful if you're working in your local development and have the queue connection set to "sync". 

This pull requests solves the issue mentioned in https://github.com/laravel-workflow/laravel-workflow/issues/72
