### PR TITLE
Configure base model

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\WorkflowStub;

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-use Illuminate\Database\Eloquent\Model;
-
 class StoredWorkflowException extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-use Illuminate\Database\Eloquent\Model;
-
 class StoredWorkflowLog extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-use Illuminate\Database\Eloquent\Model;
-
 class StoredWorkflowSignal extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-use Illuminate\Database\Eloquent\Model;
-
 class StoredWorkflowTimer extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Providers/WorkflowServiceProvider.php
+++ b/src/Providers/WorkflowServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow\Providers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
 
@@ -11,6 +12,10 @@ final class WorkflowServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        if (! class_exists('Workflow\Models\Model')) {
+            class_alias(config('workflows.base_model', Model::class), 'Workflow\Models\Model');
+        }
+
         SerializableClosure::setSecretKey(config('app.key'));
 
         $this->publishes([

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 return [
+    'base_model' => Illuminate\Database\Eloquent\Model::class,
+
     'stored_workflow_model' => Workflow\Models\StoredWorkflow::class,
 
     'stored_workflow_exception_model' => Workflow\Models\StoredWorkflowException::class,


### PR DESCRIPTION
Resolves #109.

Adds a configuration option to specify the base model.

For example you can change:

```
    'base_model' => Illuminate\Database\Eloquent\Model::class,
```

to

```
    'base_model' => Jenssegers\Mongodb\Eloquent\Model::class,
```

And now you can use this package with mongodb.