### PR TITLE
Allow relationship table name override

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -63,7 +63,7 @@ class StoredWorkflow extends Model
     {
         return $this->belongsToMany(
             config('workflows.stored_workflow_model', self::class),
-            'workflow_relationships',
+            config('workflows.workflow_relationships_table', 'workflow_relationships'),
             'child_workflow_id',
             'parent_workflow_id'
         )->withPivot(['parent_index', 'parent_now']);
@@ -73,7 +73,7 @@ class StoredWorkflow extends Model
     {
         return $this->belongsToMany(
             config('workflows.stored_workflow_model', self::class),
-            'workflow_relationships',
+            config('workflows.workflow_relationships_table', 'workflow_relationships'),
             'parent_workflow_id',
             'child_workflow_id'
         )->withPivot(['parent_index', 'parent_now']);

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -14,4 +14,6 @@ return [
     'stored_workflow_signal_model' => Workflow\Models\StoredWorkflowSignal::class,
 
     'stored_workflow_timer_model' => Workflow\Models\StoredWorkflowTimer::class,
+
+    'workflow_relationships_table' => 'workflow_relationships',
 ];


### PR DESCRIPTION
Added an override to allow setting the relationship table name in the configuration. This allows the ability to modify the database structure during migrations and still maintain the table structure itself.