### PR TITLE
React promise 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^8.0.2",
         "laravel/framework": "^9.0|^10.0",
         "spatie/laravel-model-states": "^2.1",
-        "react/promise": "^2.9"
+        "react/promise": "^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^8.0.2",
         "laravel/framework": "^9.0|^10.0",
         "spatie/laravel-model-states": "^2.1",
-        "react/promise": "^3.0"
+        "react/promise": "^2.9|^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.1",


### PR DESCRIPTION
This pull request makes it possible to use react/promise 3.
Please check the [release  announcement](https://clue.engineering/2023/announcing-reactphp-promise-v3) and [change-log](https://github.com/reactphp/promise/releases/tag/v3.0.0).
I have done this and looked through the [laravel-workflow](https://github.com/laravel-workflow/laravel-workflow) source-code to check if any of the deprecated or changed functionality was used, but it looks like it didn't.
That is why I made the upgrade optional.
I have -hand-tested it with my workflows and everything works like a charm.