### PR TITLE
Add async

### DIFF
--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use Laravel\SerializableClosure\SerializableClosure;
 use function React\Promise\all;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
@@ -16,6 +17,11 @@ final class ActivityStub
     public static function all(iterable $promises): PromiseInterface
     {
         return all([...$promises]);
+    }
+
+    public static function async(callable $callback): PromiseInterface
+    {
+        return ChildWorkflowStub::make(AsyncWorkflow::class, new SerializableClosure($callback));
     }
 
     public static function make($activity, ...$arguments): PromiseInterface

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use Generator;
+
 final class AsyncWorkflow extends Workflow
 {
     public function execute($callback)
     {
-        return yield from ($callback->getClosure())();
+        $coroutine = ($callback->getClosure())();
+        return ($coroutine instanceof Generator) ? yield from $coroutine : $coroutine;
     }
 }

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow;
+
+final class AsyncWorkflow extends Workflow
+{
+    public function execute($callback)
+    {
+        return yield from ($callback->getClosure())();
+    }
+}

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -22,10 +22,6 @@ final class AsyncWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
-            ->pluck('class')
-            ->sort()
-            ->values()
-            ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs() ->pluck('class') ->sort() ->values() ->toArray());
     }
 }

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -22,10 +22,6 @@ final class AsyncWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
-            ->pluck('class')
-            ->sort()
-            ->values()
-            ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()->pluck('class')->sort()->values()->toArray());
     }
 }

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -22,6 +22,10 @@ final class AsyncWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs() ->pluck('class') ->sort() ->values() ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
     }
 }

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestAsyncWorkflow;
+use Tests\TestCase;
+use Workflow\AsyncWorkflow;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+final class AsyncWorkflowTest extends TestCase
+{
+    public function testAsyncWorkflow(): void
+    {
+        $workflow = WorkflowStub::make(TestAsyncWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+}

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -89,10 +89,6 @@ final class ParentWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
-            ->pluck('class')
-            ->sort()
-            ->values()
-            ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()->pluck('class')->sort()->values()->toArray());
     }
 }

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -89,10 +89,6 @@ final class ParentWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
-            ->pluck('class')
-            ->sort()
-            ->values()
-            ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs() ->pluck('class') ->sort() ->values() ->toArray());
     }
 }

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -89,6 +89,10 @@ final class ParentWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([AsyncWorkflow::class], $workflow->logs() ->pluck('class') ->sort() ->values() ->toArray());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
     }
 }

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -8,10 +8,12 @@ use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestChildExceptionWorkflow;
 use Tests\Fixtures\TestChildTimerWorkflow;
 use Tests\Fixtures\TestChildWorkflow;
+use Tests\Fixtures\TestParentAsyncWorkflow;
 use Tests\Fixtures\TestParentExceptionWorkflow;
 use Tests\Fixtures\TestParentTimerWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\TestCase;
+use Workflow\AsyncWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
@@ -71,6 +73,23 @@ final class ParentWorkflowTest extends TestCase
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
         $this->assertSame([TestActivity::class, TestChildTimerWorkflow::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+
+    public function testAsync(): void
+    {
+        $workflow = WorkflowStub::make(TestParentAsyncWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([AsyncWorkflow::class], $workflow->logs()
             ->pluck('class')
             ->sort()
             ->values()

--- a/tests/Fixtures/TestAsyncWorkflow.php
+++ b/tests/Fixtures/TestAsyncWorkflow.php
@@ -6,17 +6,16 @@ namespace Tests\Fixtures;
 
 use Workflow\ActivityStub;
 use Workflow\Workflow;
-use Workflow\WorkflowStub;
 
 final class TestAsyncWorkflow extends Workflow
 {
     public function execute()
     {
-        $results = yield ActivityStub::async(function() {
+        $results = yield ActivityStub::async(static function () {
             $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
             $result = yield ActivityStub::make(TestActivity::class);
-            
+
             return [$otherResult, $result];
         });
 

--- a/tests/Fixtures/TestAsyncWorkflow.php
+++ b/tests/Fixtures/TestAsyncWorkflow.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+final class TestAsyncWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $results = yield ActivityStub::async(function() {
+            $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+            $result = yield ActivityStub::make(TestActivity::class);
+            
+            return [$otherResult, $result];
+        });
+
+        $otherResult = $results[0];
+        $result = $results[1];
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}

--- a/tests/Fixtures/TestParentAsyncWorkflow.php
+++ b/tests/Fixtures/TestParentAsyncWorkflow.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\ChildWorkflowStub;
+use Workflow\Workflow;
+
+class TestParentAsyncWorkflow extends Workflow
+{
+    public $connection = 'redis';
+
+    public $queue = 'default';
+
+    public function execute()
+    {
+        $results = yield ActivityStub::async(function() {
+            $otherResult = yield ChildWorkflowStub::make(TestChildWorkflow::class);
+
+            $result = yield ActivityStub::make(TestActivity::class);
+            
+            return [$otherResult, $result];
+        });
+
+        $otherResult = $results[0];
+        $result = $results[1];
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}

--- a/tests/Fixtures/TestParentAsyncWorkflow.php
+++ b/tests/Fixtures/TestParentAsyncWorkflow.php
@@ -16,11 +16,11 @@ class TestParentAsyncWorkflow extends Workflow
 
     public function execute()
     {
-        $results = yield ActivityStub::async(function() {
+        $results = yield ActivityStub::async(static function () {
             $otherResult = yield ChildWorkflowStub::make(TestChildWorkflow::class);
 
             $result = yield ActivityStub::make(TestActivity::class);
-            
+
             return [$otherResult, $result];
         });
 

--- a/tests/Unit/AsyncWorkflowTest.php
+++ b/tests/Unit/AsyncWorkflowTest.php
@@ -7,7 +7,6 @@ namespace Tests\Unit;
 use Laravel\SerializableClosure\SerializableClosure;
 use Tests\TestCase;
 use Workflow\AsyncWorkflow;
-use Workflow\Models\StoredWorkflow;
 use Workflow\WorkflowStub;
 
 final class AsyncWorkflowTest extends TestCase
@@ -15,8 +14,8 @@ final class AsyncWorkflowTest extends TestCase
     public function testWorkflow(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(AsyncWorkflow::class)->id());
-        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $workflow->start(new SerializableClosure(static fn () => 'test'));
+
         $this->assertSame('test', $workflow->output());
     }
 }

--- a/tests/Unit/AsyncWorkflowTest.php
+++ b/tests/Unit/AsyncWorkflowTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Laravel\SerializableClosure\SerializableClosure;
+use Tests\TestCase;
+use Workflow\AsyncWorkflow;
+use Workflow\Models\StoredWorkflow;
+use Workflow\WorkflowStub;
+
+final class AsyncWorkflowTest extends TestCase
+{
+    public function testWorkflow(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(AsyncWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $workflow->start(new SerializableClosure(static fn () => 'test'));
+        $this->assertSame('test', $workflow->output());
+    }
+}


### PR DESCRIPTION
`ActivityStub::async()` takes a callback and runs it in a child workflow.

Example usage:

```
$string = 'other';

$results = yield ActivityStub::async(function() use ($string) {
    $result = yield ActivityStub::make(SimpleActivity::class);

    $otherResult = yield ActivityStub::make(SimpleOtherActivity::class, $string);

    return [$result, $otherResult];
});
```