### PR TITLE
Don't emit exception

### DIFF
--- a/src/Events/WorkflowFailed.php
+++ b/src/Events/WorkflowFailed.php
@@ -14,7 +14,6 @@ class WorkflowFailed
 
     public function __construct(
         public int $workflowId,
-        public string $output,
         public string $timestamp,
     ) {
     }

--- a/src/Listeners/MonitorWorkflowFailed.php
+++ b/src/Listeners/MonitorWorkflowFailed.php
@@ -28,7 +28,6 @@ class MonitorWorkflowFailed implements ShouldQueue
                 ],
             ])
             ->patch(config('workflows.monitor_url') . '/rest/v1/workflows', [
-                'output' => $event->output,
                 'status' => 'failed',
                 'updated_at' => $event->timestamp,
             ]);

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -216,7 +216,6 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
             WorkflowCompleted::dispatch(
                 $this->storedWorkflow->id,
-                json_encode($return),
                 now()
                     ->format('Y-m-d\TH:i:s.u\Z')
             );

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -216,6 +216,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
             WorkflowCompleted::dispatch(
                 $this->storedWorkflow->id,
+                json_encode($return),
                 now()
                     ->format('Y-m-d\TH:i:s.u\Z')
             );

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -226,7 +226,7 @@ final class WorkflowStub
 
         $this->storedWorkflow->status->transitionTo(WorkflowFailedStatus::class);
 
-        WorkflowFailed::dispatch($this->storedWorkflow->id, now() ->format('Y-m-d\TH:i:s.u\Z'));
+        WorkflowFailed::dispatch($this->storedWorkflow->id, now()->format('Y-m-d\TH:i:s.u\Z'));
 
         $this->storedWorkflow->parents()
             ->each(static function ($parentWorkflow) use ($exception) {

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -226,8 +226,7 @@ final class WorkflowStub
 
         $this->storedWorkflow->status->transitionTo(WorkflowFailedStatus::class);
 
-        WorkflowFailed::dispatch($this->storedWorkflow->id, json_encode($exception->getMessage()), now()
-            ->format('Y-m-d\TH:i:s.u\Z'));
+        WorkflowFailed::dispatch($this->storedWorkflow->id, now() ->format('Y-m-d\TH:i:s.u\Z'));
 
         $this->storedWorkflow->parents()
             ->each(static function ($parentWorkflow) use ($exception) {

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -7,9 +7,7 @@ namespace Workflow;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use LimitIterator;
 use ReflectionClass;
-use SplFileObject;
 use Workflow\Events\WorkflowFailed;
 use Workflow\Events\WorkflowStarted;
 use Workflow\Models\StoredWorkflow;
@@ -228,18 +226,7 @@ final class WorkflowStub
 
         $this->storedWorkflow->status->transitionTo(WorkflowFailedStatus::class);
 
-        $file = new SplFileObject($exception->getFile());
-        $iterator = new LimitIterator($file, max(0, $exception->getLine() - 4), 7);
-
-        WorkflowFailed::dispatch($this->storedWorkflow->id, json_encode([
-            'class' => get_class($exception),
-            'message' => $exception->getMessage(),
-            'code' => $exception->getCode(),
-            'line' => $exception->getLine(),
-            'file' => $exception->getFile(),
-            'trace' => $exception->getTrace(),
-            'snippet' => array_slice(iterator_to_array($iterator), 0, 7),
-        ]), now()
+        WorkflowFailed::dispatch($this->storedWorkflow->id, json_encode($exception->getMessage()), now()
             ->format('Y-m-d\TH:i:s.u\Z'));
 
         $this->storedWorkflow->parents()

--- a/tests/Unit/Commands/ActivityMakeCommandTest.php
+++ b/tests/Unit/Commands/ActivityMakeCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;

--- a/tests/Unit/Commands/WorkflowMakeCommandTest.php
+++ b/tests/Unit/Commands/WorkflowMakeCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;

--- a/tests/Unit/Listeners/MonitorActivityCompletedTest.php
+++ b/tests/Unit/Listeners/MonitorActivityCompletedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/Listeners/MonitorActivityFailedTest.php
+++ b/tests/Unit/Listeners/MonitorActivityFailedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/Listeners/MonitorActivityStartedTest.php
+++ b/tests/Unit/Listeners/MonitorActivityStartedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/Listeners/MonitorWorkflowCompletedTest.php
+++ b/tests/Unit/Listeners/MonitorWorkflowCompletedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/Listeners/MonitorWorkflowFailedTest.php
+++ b/tests/Unit/Listeners/MonitorWorkflowFailedTest.php
@@ -45,7 +45,6 @@ final class MonitorWorkflowFailedTest extends TestCase
                 $request->hasHeader('Authorization', 'Bearer token') &&
                 $request->url() === 'http://test/rest/v1/workflows?user_id=eq.user&workflow_id=eq.1' &&
                 $data->status === 'failed' &&
-                $data->output === 'output' &&
                 $data->updated_at === 'time';
         });
     }

--- a/tests/Unit/Listeners/MonitorWorkflowFailedTest.php
+++ b/tests/Unit/Listeners/MonitorWorkflowFailedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -30,7 +30,7 @@ final class MonitorWorkflowFailedTest extends TestCase
             'rest/v1/workflows?user_id=eq.user&workflow_id=eq.1' => Http::response(),
         ]);
 
-        $event = new WorkflowFailed(1, 'output', 'time');
+        $event = new WorkflowFailed(1, 'time');
         $listener = new MonitorWorkflowFailed();
         $listener->handle($event);
 

--- a/tests/Unit/Listeners/MonitorWorkflowStartedTest.php
+++ b/tests/Unit/Listeners/MonitorWorkflowStartedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Unit\Listeners;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;


### PR DESCRIPTION
Don't emit the exception on a failed workflow event. It is always the same value of 'Workflow failed.' and therefore isn't useful.