### PR TITLE
Should use a storedWorkflow from the class property instead of the static context

### DIFF
--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -32,7 +32,6 @@ final class WorkflowStub
 
     /**
      * It's used only in queues for storing current context
-     * @var \stdClass|null
      */
     private static ?\stdClass $context = null;
 
@@ -66,7 +65,8 @@ final class WorkflowStub
             return Signal::dispatch(
                 $this->storedWorkflow,
                 Arr::get($workflowClassProps, 'connection'),
-                Arr::get($workflowClassProps, 'queue'));
+                Arr::get($workflowClassProps, 'queue')
+            );
         }
 
         if (collect((new ReflectionClass($this->storedWorkflow->class))->getMethods())

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -30,6 +30,10 @@ final class WorkflowStub
     use SideEffects;
     use Timers;
 
+    /**
+     * It's used only in queues for storing current context
+     * @var \stdClass|null
+     */
     private static ?\stdClass $context = null;
 
     private function __construct(
@@ -57,7 +61,12 @@ final class WorkflowStub
                     'arguments' => Y::serialize($arguments),
                 ]);
 
-            return Signal::dispatch($this->storedWorkflow, self::connection(), self::queue());
+            $workflowClassProps = (new ReflectionClass($this->storedWorkflow->class))->getDefaultProperties();
+
+            return Signal::dispatch(
+                $this->storedWorkflow,
+                Arr::get($workflowClassProps, 'connection'),
+                Arr::get($workflowClassProps, 'queue'));
         }
 
         if (collect((new ReflectionClass($this->storedWorkflow->class))->getMethods())

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -30,9 +30,6 @@ final class WorkflowStub
     use SideEffects;
     use Timers;
 
-    /**
-     * It's used only in queues for storing current context
-     */
     private static ?\stdClass $context = null;
 
     private function __construct(
@@ -60,13 +57,9 @@ final class WorkflowStub
                     'arguments' => Y::serialize($arguments),
                 ]);
 
-            $workflowClassProps = (new ReflectionClass($this->storedWorkflow->class))->getDefaultProperties();
+            $workflow = $this->storedWorkflow->toWorkflow();
 
-            return Signal::dispatch(
-                $this->storedWorkflow,
-                Arr::get($workflowClassProps, 'connection'),
-                Arr::get($workflowClassProps, 'queue')
-            );
+            return Signal::dispatch($this->storedWorkflow, self::connection(), self::queue());
         }
 
         if (collect((new ReflectionClass($this->storedWorkflow->class))->getMethods())

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -57,7 +57,7 @@ final class WorkflowStub
                     'arguments' => Y::serialize($arguments),
                 ]);
 
-            $workflow = $this->storedWorkflow->toWorkflow();
+            $this->storedWorkflow->toWorkflow();
 
             return Signal::dispatch($this->storedWorkflow, self::connection(), self::queue());
         }

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use Exception;
 use Illuminate\Support\Carbon;
 use Tests\Fixtures\TestAwaitWorkflow;
+use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
@@ -192,5 +193,18 @@ final class WorkflowStubTest extends TestCase
             'class' => Signal::class,
         ]);
         $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+    }
+
+    public function testConnection(): void
+    {
+        Carbon::setTestNow('2022-01-01');
+
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $otherWorkflow = WorkflowStub::load(WorkflowStub::make(TestBadConnectionWorkflow::class)->id());
+
+        $workflow->cancel();
+
+        $this->assertSame('redis', WorkflowStub::connection());
+        $this->assertSame('default', WorkflowStub::queue());
     }
 }


### PR DESCRIPTION
This PR fixes the bug that leads to using a wrong queue and connection with multiple workflows

```
$workflow1 = WorkflowStub::make(MyWorkflow::class);
$workflow2 = WorkflowStub::make(MyWorkflow2::class); // <- This workflow overwrites static context

$workflow1->start();
$workflow2->start();

$workflow1->setTestString('string 1'); // <- this signal uses connection and queue from workflow 2 because it uses info from the context that was overwritten. This PR fixes it
$workflow2->setTestString('string 2');
```

