### PR TITLE
WIP: PHPStan

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/phpstan ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -57,7 +57,7 @@ jobs:
       run: vendor/bin/ecs check
 
     - name: Run static analysis via PHPStan
-      run: vendor/bin/phpstan --xdebug analyse src tests
+      run: vendor/bin/phpstan analyse src tests
 
     - name: Create databases
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,6 +64,22 @@ jobs:
         touch testbench.sqlite
         mysql -e 'CREATE DATABASE testbench' -h127.0.0.1 -uroot -ppassword -P ${{ job.services.mysql.ports[3306] }}
 
+    - name: Run test suite (Unit)
+      run: vendor/bin/phpunit --testdox --testsuite unit
+      env:
+        APP_KEY: base64:i3g6f+dV8FfsIkcxqd7gbiPn2oXk5r00sTmdD6V5utI=
+        DB_CONNECTION: mysql
+        DB_DATABASE: testbench
+        DB_HOST: 127.0.0.1
+        DB_PORT: 3306
+        DB_USERNAME: root
+        DB_PASSWORD: password
+        QUEUE_CONNECTION: sync
+        CACHE_DRIVER: array
+        REDIS_HOST: 127.0.0.1
+        REDIS_PASSWORD: ""
+        REDIS_PORT: 6379
+
     - name: Run test suite (MySQL)
       run: vendor/bin/phpunit --testdox --testsuite feature
       env:
@@ -75,8 +91,9 @@ jobs:
         DB_USERNAME: root
         DB_PASSWORD: password
         QUEUE_CONNECTION: redis
+        CACHE_DRIVER: redis
         REDIS_HOST: 127.0.0.1
-        REDIS_PASSWORD:
+        REDIS_PASSWORD: ""
         REDIS_PORT: 6379
 
     - name: Run test suite (PostgreSQL)
@@ -90,8 +107,9 @@ jobs:
         DB_USERNAME: root
         DB_PASSWORD: password
         QUEUE_CONNECTION: redis
+        CACHE_DRIVER: redis
         REDIS_HOST: 127.0.0.1
-        REDIS_PASSWORD:
+        REDIS_PASSWORD: ""
         REDIS_PORT: 6379
 
     - name: Code Coverage
@@ -103,4 +121,5 @@ jobs:
         DB_CONNECTION: sqlite
         DB_DATABASE: testbench.sqlite
         QUEUE_CONNECTION: sync
+        CACHE_DRIVER: array
         XDEBUG_MODE: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 .php_cs.cache
 .php-cs-fixer.cache
 .idea
+.phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ There's also a [sample application](https://github.com/laravel-workflow/sample-a
 ```php
 use Workflow\ActivityStub;
 use Workflow\Workflow;
+use Generator
 
 class MyWorkflow extends Workflow
 {
-    public function execute($name)
+    public function execute($name): Generator
     {
         $result = yield ActivityStub::make(MyActivity::class, $name);
         return $result;
@@ -48,10 +49,11 @@ class MyWorkflow extends Workflow
 **2. Create an activity.**
 ```php
 use Workflow\Activity;
+use Generator;
 
 class MyActivity extends Activity
 {
-    public function execute($name)
+    public function execute($name): Generator
     {
         return "Hello, {$name}!";
     }

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ class MyWorkflow extends Workflow
 **2. Create an activity.**
 ```php
 use Workflow\Activity;
-use Generator;
 
 class MyActivity extends Activity
 {
-    public function execute($name): Generator
+    public function execute(string $name): string
     {
         return "Hello, {$name}!";
     }

--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,21 @@
         "phpstan/phpstan": "^1.9",
         "rector/rector": "^0.15.1",
         "scrutinizer/ocular": "dev-master",
-        "symplify/easy-coding-standard": "^11.1"
+        "symplify/easy-coding-standard": "^11.1",
+        "larastan/larastan": "^2.8",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-strict-rules": "^1.5"
     },
     "extra": {
         "laravel": {
             "providers": [
                 "Workflow\\Providers\\WorkflowServiceProvider"
             ]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "php": "^8.0.2",
         "laravel/framework": "^9.0|^10.0",
         "spatie/laravel-model-states": "^2.1",
-        "react/promise": "^2.9|^3.0"
+        "react/promise": "^2.9|^3.0",
+        "doctrine/dbal": "^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.1",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,11 @@
             "providers": [
                 "Workflow\\Providers\\WorkflowServiceProvider"
             ]
+        },
+        "phpstan": {
+            "includes": [
+                "src/PHPStan/extension.neon"
+            ]
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symplify/easy-coding-standard": "^11.1",
         "larastan/larastan": "^2.8",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.5"
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan-mockery": "^1.1"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,16 @@
         "rector": "vendor/bin/rector",
         "ecs": "vendor/bin/ecs check --fix",
         "stan": "vendor/bin/phpstan analyse src tests",
-        "feature": "phpunit --testdox --testsuite feature",
-        "unit": "phpunit --testdox --testsuite unit",
+        "feature": [
+            "@putenv QUEUE_CONNECTION=redis",
+            "@putenv CACHE_DRIVER=redis",
+            "phpunit --testdox --testsuite feature"
+        ],
+        "unit": [
+            "@putenv QUEUE_CONNECTION=sync",
+            "@putenv CACHE_DRIVER=array",
+            "phpunit --testdox --testsuite unit"
+        ],
         "test": "phpunit --testdox"
     },
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 0
+    level: 1
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 7
+    level: 8
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 3
+    level: 4
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 4
+    level: 6
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     strictRules:
         strictCalls: false
     parallel:
-        maximumNumberOfProcesses: 4
+        maximumNumberOfProcesses: 8
     tmpDir: .phpstan
     paths:
         - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 2
+    level: 3
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+    - src/PHPStan/extension.neon
 parameters:
     strictRules:
         strictCalls: false
@@ -16,3 +18,4 @@ parameters:
         - classAliases.php
     excludePaths:
         - ./src/migrations/*.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
     strictRules:
         strictCalls: false
+        noVariableVariables: false
     parallel:
         maximumNumberOfProcesses: 8
     tmpDir: .phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,17 @@
 parameters:
+    strictRules:
+        strictCalls: false
+    parallel:
+        maximumNumberOfProcesses: 4
+    tmpDir: .phpstan
+    paths:
+        - src/
+        - tests/
+    databaseMigrationsPath:
+        - src/migrations/
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
     level: 0
     bootstrapFiles:
         - classAliases.php
+    excludePaths:
+        - ./src/migrations/*.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 6
+    level: 7
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,7 @@ parameters:
     databaseMigrationsPath:
         - src/migrations/
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-    level: 1
+    level: 2
     bootstrapFiles:
         - classAliases.php
     excludePaths:

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -15,8 +15,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
-use LimitIterator;
-use SplFileObject;
 use Throwable;
 use Workflow\Exceptions\Transformer;
 use Workflow\Middleware\WithoutOverlappingMiddleware;

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -35,31 +35,38 @@ abstract class Activity implements ShouldBeEncrypted, ShouldQueue
     use RouteDependencyResolverTrait;
     use SerializesModels;
 
-    /** @var int  */
+    /**
+     * @var int
+     */
     public $tries = PHP_INT_MAX;
 
-    /** @var int  */
+    /**
+     * @var int
+     */
     public $maxExceptions = PHP_INT_MAX;
 
-    /** @var int  */
+    /**
+     * @var int
+     */
     public $timeout = 0;
 
-    /** @var array<int|string, mixed> */
+    /**
+     * @var array<int|string, mixed>
+     */
     public $arguments;
 
-    /** @var string  */
+    /**
+     * @var string
+     */
     public $key = '';
 
     /**
      * The container property is needed in the @see RouteDependencyResolverTrait
      * which in turn is used to dynamically resolve the "execute" method parameters.
-     * @phpstan-ignore-next-line
      */
-    private Container $container;
+    private Container $container; // @phpstan-ignore-line
 
     /**
-     * @param int $index
-     * @param string $now
      * @param StoredWorkflow<TWorkflow, null> $storedWorkflow
      * @param mixed ...$arguments
      */
@@ -162,7 +169,8 @@ abstract class Activity implements ShouldBeEncrypted, ShouldQueue
             $this->now,
             $this->storedWorkflow,
             $throwable,
-        )->onConnection($workflow->connection())->onQueue($workflow->queue());
+        )->onConnection($workflow->connection())
+            ->onQueue($workflow->queue());
     }
 
     public function heartbeat(): void

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -56,13 +56,9 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     ) {
         $this->arguments = $arguments;
 
-        if (property_exists($this, 'connection')) {
-            $this->onConnection($this->connection);
-        }
+        $this->onConnection($this->connection ?? null);
 
-        if (property_exists($this, 'queue')) {
-            $this->onQueue($this->queue);
-        }
+        $this->onQueue($this->queue ?? null);
 
         $this->afterCommit = true;
     }

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -44,7 +44,7 @@ abstract class Activity implements ShouldBeEncrypted, ShouldQueue
     /** @var int  */
     public $timeout = 0;
 
-    /** @var array<int, mixed> */
+    /** @var array<int|string, mixed> */
     public $arguments;
 
     /** @var string  */

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -22,11 +22,9 @@ use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Middleware\WorkflowMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;
-use function PHPStan\dumpType;
 
 /**
  * @template TWorkflow of Workflow
- * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
  * @template TReturn
  */
 abstract class Activity implements ShouldBeEncrypted, ShouldQueue
@@ -62,7 +60,7 @@ abstract class Activity implements ShouldBeEncrypted, ShouldQueue
     /**
      * @param int $index
      * @param string $now
-     * @param TStoredWorkflow $storedWorkflow
+     * @param StoredWorkflow<TWorkflow, null> $storedWorkflow
      * @param mixed ...$arguments
      */
     public function __construct(

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -31,14 +31,19 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     use RouteDependencyResolverTrait;
     use SerializesModels;
 
+    /** @var int  */
     public $tries = PHP_INT_MAX;
 
+    /** @var int  */
     public $maxExceptions = PHP_INT_MAX;
 
+    /** @var int  */
     public $timeout = 0;
 
+    /** @var array<int, mixed> */
     public $arguments;
 
+    /** @var string  */
     public $key = '';
 
     /**
@@ -63,11 +68,17 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
+    /**
+     * @return int[]
+     */
     public function backoff()
     {
         return [1, 2, 5, 10, 15, 30, 60, 120];
     }
 
+    /**
+     * @return int
+     */
     public function workflowId()
     {
         return $this->storedWorkflow->id;
@@ -98,6 +109,9 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
+    /**
+     * @return list<mixed>
+     */
     public function middleware()
     {
         return [
@@ -141,7 +155,10 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     public function heartbeat(): void
     {
         pcntl_alarm(max($this->timeout, 0));
-        if ($this->timeout) {
+        if ($this->timeout > 0) {
+            /**
+             * NOTE: the key is set in @see WithoutOverlappingMiddleware in the lock function
+             */
             Cache::put($this->key, 1, $this->timeout);
         }
     }

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -134,9 +134,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
             $this->now,
             $this->storedWorkflow,
             $throwable,
-            $workflow->connection(),
-            $workflow->queue()
-        );
+        )->onConnection($workflow->connection())->onQueue($workflow->queue());
     }
 
     public function heartbeat(): void

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -22,8 +22,14 @@ use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Middleware\WorkflowMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;
+use function PHPStan\dumpType;
 
-class Activity implements ShouldBeEncrypted, ShouldQueue
+/**
+ * @template TWorkflow of Workflow
+ * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
+ * @template TReturn
+ */
+abstract class Activity implements ShouldBeEncrypted, ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -53,6 +59,12 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
      */
     private Container $container;
 
+    /**
+     * @param int $index
+     * @param string $now
+     * @param TStoredWorkflow $storedWorkflow
+     * @param mixed ...$arguments
+     */
     public function __construct(
         public int $index,
         public string $now,
@@ -84,6 +96,9 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         return $this->storedWorkflow->id;
     }
 
+    /**
+     * @return void | TReturn
+     */
     public function handle()
     {
         if (! method_exists($this, 'execute')) {

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -41,6 +41,11 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
 
     public $key = '';
 
+    /**
+     * The container property is needed in the @see RouteDependencyResolverTrait
+     * which in turn is used to dynamically resolve the "execute" method parameters.
+     * @phpstan-ignore-next-line
+     */
     private Container $container;
 
     public function __construct(

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -85,7 +85,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         }
 
         try {
-            return $this->{'execute'}(...$this->resolveClassMethodDependencies($this->arguments, $this, 'execute'));
+            return $this->execute(...$this->resolveClassMethodDependencies($this->arguments, $this, 'execute'));
         } catch (\Throwable $throwable) {
             $this->storedWorkflow->exceptions()
                 ->create([

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -7,7 +7,6 @@ namespace Workflow;
 use Generator;
 use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
-use Workflow\Models\StoredWorkflow;
 use function React\Promise\all;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
@@ -17,15 +16,14 @@ use Workflow\Serializers\Y;
 
 /**
  * @template TWorkflow of Workflow
- * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
  * @template TReturn
- * @template TActivity of Activity<TWorkflow, TStoredWorkflow, TReturn>
+ * @template TActivity of Activity<TWorkflow, TReturn>
  */
 final class ActivityStub
 {
     /**
-     * @param iterable<PromiseInterface<TActivity<TWorkflow, TStoredWorkflow, TReturn>>> $promises
-     * @return PromiseInterface<TActivity<TWorkflow, TStoredWorkflow, TReturn>[]>
+     * @param iterable<PromiseInterface<TActivity<TWorkflow, TReturn>>> $promises
+     * @return PromiseInterface<TActivity<TWorkflow, TReturn>[]>
      */
     public static function all(iterable $promises): PromiseInterface
     {
@@ -45,9 +43,8 @@ final class ActivityStub
 
     /**
      * @template TMakeWorkflowClass of Workflow
-     * @template TMakeStoredWorkflow of StoredWorkflow<TWorkflow, null>
      * @template TMakeActivityReturn
-     * @template TMakeActivityClass of Activity<TMakeWorkflowClass, TMakeStoredWorkflow, TMakeActivityReturn>
+     * @template TMakeActivityClass of Activity<TMakeWorkflowClass, TMakeActivityReturn>
      * @param class-string<TMakeActivityClass> $activity
      * @param list<mixed> ...$arguments
      * @return PromiseInterface<TMakeActivityClass>

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -6,10 +6,7 @@ namespace Workflow;
 
 use Carbon\Carbon;
 use Closure;
-use Generator;
-use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
-use function PHPStan\dumpType;
 use function React\Promise\all;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
@@ -34,12 +31,7 @@ final class ActivityStub
     }
 
     /**
-     * @param Closure $callback
      * @return PromiseInterface<mixed>
-     * @throws PhpVersionNotSupportedException
-     *
-     * we can only be more specific with the callable when https://github.com/phpstan/phpstan/issues/8214
-     * is implemented
      */
     public static function async(Closure $callback): PromiseInterface
     {
@@ -97,7 +89,12 @@ final class ActivityStub
             return resolve($result);
         }
 
-        $activity::dispatch($context->index, Carbon::parse($context->now)->toDateTimeString(), $context->storedWorkflow, ...$arguments);
+        $activity::dispatch(
+            $context->index,
+            Carbon::parse($context->now)->toDateTimeString(),
+            $context->storedWorkflow,
+            ...$arguments
+        );
 
         ++$context->index;
         WorkflowStub::setContext($context);

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -91,7 +91,7 @@ final class ActivityStub
 
         $activity::dispatch(
             $context->index,
-            Carbon::parse($context->now)->toDateTimeString(),
+            Carbon::parse($context->now)->format('Y-m-d\TH:i:s.u\Z'),
             $context->storedWorkflow,
             ...$arguments
         );

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use Closure;
 use Generator;
 use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -31,10 +32,12 @@ final class ActivityStub
     }
 
     /**
-     * @template TAsyncReturn
-     * @param callable():(TAsyncReturn|Generator<int, mixed, void, TAsyncReturn>) $callback
-     * @return PromiseInterface<TAsyncReturn>
+     * @param callable $callback
+     * @return PromiseInterface<mixed>
      * @throws PhpVersionNotSupportedException
+     *
+     * we can only be more specific with the callable when https://github.com/phpstan/phpstan/issues/8214
+     * is implemented
      */
     public static function async(callable $callback): PromiseInterface
     {
@@ -46,7 +49,7 @@ final class ActivityStub
      * @template TMakeActivityReturn
      * @template TMakeActivityClass of Activity<TMakeWorkflowClass, TMakeActivityReturn>
      * @param class-string<TMakeActivityClass> $activity
-     * @param list<mixed> ...$arguments
+     * @param mixed ...$arguments
      * @return PromiseInterface<TMakeActivityClass>
      */
     public static function make($activity, ...$arguments): PromiseInterface

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use Generator;
+use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
+use Workflow\Models\StoredWorkflow;
 use function React\Promise\all;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
@@ -12,18 +15,43 @@ use function React\Promise\resolve;
 use Throwable;
 use Workflow\Serializers\Y;
 
+/**
+ * @template TWorkflow of Workflow
+ * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
+ * @template TReturn
+ * @template TActivity of Activity<TWorkflow, TStoredWorkflow, TReturn>
+ */
 final class ActivityStub
 {
+    /**
+     * @param iterable<PromiseInterface<TActivity<TWorkflow, TStoredWorkflow, TReturn>>> $promises
+     * @return PromiseInterface<TActivity<TWorkflow, TStoredWorkflow, TReturn>[]>
+     */
     public static function all(iterable $promises): PromiseInterface
     {
         return all([...$promises]);
     }
 
+    /**
+     * @template TAsyncReturn
+     * @param callable():(TAsyncReturn|Generator<int, mixed, void, TAsyncReturn>) $callback
+     * @return PromiseInterface<TAsyncReturn>
+     * @throws PhpVersionNotSupportedException
+     */
     public static function async(callable $callback): PromiseInterface
     {
         return ChildWorkflowStub::make(AsyncWorkflow::class, new SerializableClosure($callback));
     }
 
+    /**
+     * @template TMakeWorkflowClass of Workflow
+     * @template TMakeStoredWorkflow of StoredWorkflow<TWorkflow, null>
+     * @template TMakeActivityReturn
+     * @template TMakeActivityClass of Activity<TMakeWorkflowClass, TMakeStoredWorkflow, TMakeActivityReturn>
+     * @param class-string<TMakeActivityClass> $activity
+     * @param list<mixed> ...$arguments
+     * @return PromiseInterface<TMakeActivityClass>
+     */
     public static function make($activity, ...$arguments): PromiseInterface
     {
         $context = WorkflowStub::getContext();

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -26,11 +26,11 @@ final class AsyncWorkflow extends Workflow
 
     /**
      * @param SerializableClosure $callback
-     * @return TReturn|Generator<int, mixed, void, TReturn>
+     * @return Generator<int, mixed, void, TReturn>
      * @throws ReflectionException
      * @throws PhpVersionNotSupportedException
      */
-    public function execute($callback)
+    public function execute($callback): Generator
     {
         $this->container = App::make(Container::class);
         $callable = $callback->getClosure();

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -7,9 +7,7 @@ namespace Workflow;
 use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\App;
-use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
-use ReflectionException;
 use ReflectionFunction;
 
 /**
@@ -20,15 +18,12 @@ final class AsyncWorkflow extends Workflow
     /**
      * The container property is needed in the @see RouteDependencyResolverTrait
      * which in turn is used to dynamically resolve the "execute" method parameters.
-     * @phpstan-ignore-next-line
      */
-    private Container $container;
+    private Container $container; // @phpstan-ignore-line
 
     /**
      * @param SerializableClosure $callback
      * @return Generator<int, mixed, void, TReturn>
-     * @throws ReflectionException
-     * @throws PhpVersionNotSupportedException
      */
     public function execute($callback): Generator
     {

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -11,6 +11,11 @@ use ReflectionFunction;
 
 final class AsyncWorkflow extends Workflow
 {
+    /**
+     * The container property is needed in the @see RouteDependencyResolverTrait
+     * which in turn is used to dynamically resolve the "execute" method parameters.
+     * @phpstan-ignore-next-line
+     */
     private Container $container;
 
     public function execute($callback)

--- a/src/AsyncWorkflow.php
+++ b/src/AsyncWorkflow.php
@@ -7,8 +7,14 @@ namespace Workflow;
 use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\App;
+use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
+use Laravel\SerializableClosure\SerializableClosure;
+use ReflectionException;
 use ReflectionFunction;
 
+/**
+ * @template TReturn
+ */
 final class AsyncWorkflow extends Workflow
 {
     /**
@@ -18,6 +24,12 @@ final class AsyncWorkflow extends Workflow
      */
     private Container $container;
 
+    /**
+     * @param SerializableClosure $callback
+     * @return TReturn|Generator<int, mixed, void, TReturn>
+     * @throws ReflectionException
+     * @throws PhpVersionNotSupportedException
+     */
     public function execute($callback)
     {
         $this->container = App::make(Container::class);

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -61,7 +61,7 @@ final class ChildWorkflowStub
         if ($log !== null) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            return resolve($log->result !== null ?  Y::unserialize($log->result) : null);
+            return resolve($log->result !== null ? Y::unserialize($log->result) : null);
         }
 
         if (! $context->replaying) {
@@ -69,7 +69,9 @@ final class ChildWorkflowStub
                 ->wherePivot('parent_index', $context->index)
                 ->first();
 
-            $childWorkflow = $storedChildWorkflow !== null ? $storedChildWorkflow->toWorkflow() : WorkflowStub::make($workflow);
+            $childWorkflow = $storedChildWorkflow !== null ? $storedChildWorkflow->toWorkflow() : WorkflowStub::make(
+                $workflow
+            );
 
             if ($childWorkflow->running() && ! $childWorkflow->created()) {
                 try {

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -10,13 +10,25 @@ use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Workflow\Serializers\Y;
 
+/**
+ * @template TWorkflow of Workflow
+ */
 final class ChildWorkflowStub
 {
+    /**
+     * @param iterable<mixed> $promises
+     * @return PromiseInterface<mixed>
+     */
     public static function all(iterable $promises): PromiseInterface
     {
         return all([...$promises]);
     }
 
+    /**
+     * @param class-string<TWorkflow> $workflow
+     * @param mixed ...$arguments
+     * @return PromiseInterface<void>
+     */
     public static function make($workflow, ...$arguments): PromiseInterface
     {
         $context = WorkflowStub::getContext();

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -40,7 +40,7 @@ final class ChildWorkflowStub
         if (WorkflowStub::faked()) {
             $mocks = WorkflowStub::mocks();
 
-            if (! $log && array_key_exists($workflow, $mocks)) {
+            if ($log === null && array_key_exists($workflow, $mocks)) {
                 $result = $mocks[$workflow];
 
                 $log = $context->storedWorkflow->logs()
@@ -55,7 +55,7 @@ final class ChildWorkflowStub
             }
         }
 
-        if ($log) {
+        if ($log !== null) {
             ++$context->index;
             WorkflowStub::setContext($context);
             return resolve(Y::unserialize($log->result));
@@ -66,7 +66,7 @@ final class ChildWorkflowStub
                 ->wherePivot('parent_index', $context->index)
                 ->first();
 
-            $childWorkflow = $storedChildWorkflow ? $storedChildWorkflow->toWorkflow() : WorkflowStub::make($workflow);
+            $childWorkflow = $storedChildWorkflow !== null ? $storedChildWorkflow->toWorkflow() : WorkflowStub::make($workflow);
 
             if ($childWorkflow->running() && ! $childWorkflow->created()) {
                 try {

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -32,6 +32,9 @@ final class ChildWorkflowStub
     public static function make($workflow, ...$arguments): PromiseInterface
     {
         $context = WorkflowStub::getContext();
+        if ($context === null) {
+            throw new \RuntimeException('ActivityStub::make() must be called within a workflow');
+        }
 
         $log = $context->storedWorkflow->logs()
             ->whereIndex($context->index)
@@ -58,7 +61,7 @@ final class ChildWorkflowStub
         if ($log !== null) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            return resolve(Y::unserialize($log->result));
+            return resolve($log->result !== null ?  Y::unserialize($log->result) : null);
         }
 
         if (! $context->replaying) {

--- a/src/Commands/ActivityMakeCommand.php
+++ b/src/Commands/ActivityMakeCommand.php
@@ -11,64 +11,22 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:activity')]
 class ActivityMakeCommand extends GeneratorCommand
 {
-    /**
-     * The console command name.
-     *
-     * @var string
-     */
     protected $name = 'make:activity';
 
-    /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:activity';
-
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Create a new activity class';
 
-    /**
-     * The type of class being generated.
-     *
-     * @var string
-     */
     protected $type = 'Activity';
 
-    /**
-     * Get the stub file for the generator.
-     *
-     * @return string
-     */
     protected function getStub()
     {
         return __DIR__ . '/stubs/activity.stub';
     }
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace . '\\' . config('workflows.workflows_folder', 'Workflows');
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
     protected function getOptions()
     {
         return [['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the activity already exists']];

--- a/src/Commands/ActivityMakeCommand.php
+++ b/src/Commands/ActivityMakeCommand.php
@@ -27,6 +27,9 @@ class ActivityMakeCommand extends GeneratorCommand
         return $rootNamespace . '\\' . config('workflows.workflows_folder', 'Workflows');
     }
 
+    /**
+     * @return list<list<string|int>>
+     */
     protected function getOptions()
     {
         return [['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the activity already exists']];

--- a/src/Commands/WorkflowMakeCommand.php
+++ b/src/Commands/WorkflowMakeCommand.php
@@ -27,6 +27,9 @@ class WorkflowMakeCommand extends GeneratorCommand
         return $rootNamespace . '\\' . config('workflows.workflows_folder', 'Workflows');
     }
 
+    /**
+     * @return list<list<string|int>>
+     */
     protected function getOptions()
     {
         return [['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the workflow already exists']];

--- a/src/Commands/WorkflowMakeCommand.php
+++ b/src/Commands/WorkflowMakeCommand.php
@@ -11,64 +11,22 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:workflow')]
 class WorkflowMakeCommand extends GeneratorCommand
 {
-    /**
-     * The console command name.
-     *
-     * @var string
-     */
     protected $name = 'make:workflow';
 
-    /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:workflow';
-
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Create a new workflow class';
 
-    /**
-     * The type of class being generated.
-     *
-     * @var string
-     */
     protected $type = 'Workflow';
 
-    /**
-     * Get the stub file for the generator.
-     *
-     * @return string
-     */
     protected function getStub()
     {
         return __DIR__ . '/stubs/workflow.stub';
     }
 
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace . '\\' . config('workflows.workflows_folder', 'Workflows');
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
     protected function getOptions()
     {
         return [['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the workflow already exists']];

--- a/src/Commands/stubs/activity.stub
+++ b/src/Commands/stubs/activity.stub
@@ -6,7 +6,7 @@ use Workflow\Activity;
 
 class {{ class }} extends Activity
 {
-    public function execute(): Generator
+    public function execute()
     {
         //
     }

--- a/src/Commands/stubs/activity.stub
+++ b/src/Commands/stubs/activity.stub
@@ -6,7 +6,7 @@ use Workflow\Activity;
 
 class {{ class }} extends Activity
 {
-    public function execute()
+    public function execute(): Generator
     {
         //
     }

--- a/src/Commands/stubs/workflow.stub
+++ b/src/Commands/stubs/workflow.stub
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }};
 
+use Generator;
 use Workflow\Workflow;
 
 class {{ class }} extends Workflow

--- a/src/Commands/stubs/workflow.stub
+++ b/src/Commands/stubs/workflow.stub
@@ -6,7 +6,7 @@ use Workflow\Workflow;
 
 class {{ class }} extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         //
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Workflow;
 
-use http\Message;
 use Workflow\Models\StoredWorkflow;
 
 /**
- * @extends Activity<Workflow, StoredWorkflow<Workflow, null>, mixed>
+ * @extends Activity<Workflow, mixed>
  */
 class Exception extends Activity
 {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use Throwable;
 use Workflow\Models\StoredWorkflow;
 
 /**
@@ -15,7 +16,7 @@ class Exception extends Activity
      * @param int $index
      * @param string $now
      * @param StoredWorkflow<Workflow, null> $storedWorkflow
-     * @param array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
+     * @param Throwable|array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
      *
      * @TODO: check if this class really must extend the Activity class. This makes typing more difficult.
      *
@@ -24,7 +25,7 @@ class Exception extends Activity
         public int $index,
         public string $now,
         public StoredWorkflow $storedWorkflow, // @phpstan-ignore-line
-        public array $exception,
+        public Throwable | array $exception,
     ) {
         parent::__construct($index, $now, $storedWorkflow);
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,13 +13,8 @@ class Exception extends Activity
         public string $now,
         public StoredWorkflow $storedWorkflow,
         public $exception,
-        $connection = null,
-        $queue = null
     ) {
-        $connection = $connection ?? config('queue.default');
-        $queue = $queue ?? config('queue.connections.' . $connection . '.queue', 'default');
-        $this->onConnection($connection);
-        $this->onQueue($queue);
+        parent::__construct($index, $now, $storedWorkflow);
     }
 
     public function handle()

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,13 +13,10 @@ use Workflow\Models\StoredWorkflow;
 class Exception extends Activity
 {
     /**
-     * @param int $index
-     * @param string $now
      * @param StoredWorkflow<Workflow, null> $storedWorkflow
      * @param Throwable|array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
      *
      * @TODO: check if this class really must extend the Activity class. This makes typing more difficult.
-     *
      */
     public function __construct(
         public int $index,

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow;
 
-use Throwable;
 use Workflow\Models\StoredWorkflow;
 
 /**

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -8,13 +8,13 @@ use Throwable;
 use Workflow\Models\StoredWorkflow;
 
 /**
- * @extends Activity<Workflow, mixed>
+ * @extends Activity<Workflow, array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]}>
  */
 class Exception extends Activity
 {
     /**
      * @param StoredWorkflow<Workflow, null> $storedWorkflow
-     * @param Throwable|array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
+     * @param array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
      *
      * @TODO: check if this class really must extend the Activity class. This makes typing more difficult.
      */
@@ -22,7 +22,7 @@ class Exception extends Activity
         public int $index,
         public string $now,
         public StoredWorkflow $storedWorkflow, // @phpstan-ignore-line
-        public Throwable | array $exception,
+        public array $exception,
     ) {
         parent::__construct($index, $now, $storedWorkflow);
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,15 +4,28 @@ declare(strict_types=1);
 
 namespace Workflow;
 
+use http\Message;
 use Workflow\Models\StoredWorkflow;
 
+/**
+ * @extends Activity<Workflow, StoredWorkflow<Workflow, null>, mixed>
+ */
 class Exception extends Activity
 {
+    /**
+     * @param int $index
+     * @param string $now
+     * @param StoredWorkflow<Workflow, null> $storedWorkflow
+     * @param array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]} $exception
+     *
+     * @TODO: check if this class really must extend the Activity class. This makes typing more difficult.
+     *
+     */
     public function __construct(
         public int $index,
         public string $now,
-        public StoredWorkflow $storedWorkflow,
-        public $exception,
+        public StoredWorkflow $storedWorkflow, // @phpstan-ignore-line
+        public array $exception,
     ) {
         parent::__construct($index, $now, $storedWorkflow);
     }

--- a/src/Exceptions/Transformer.php
+++ b/src/Exceptions/Transformer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Exceptions;
+
+use LimitIterator;
+use SplFileObject;
+use Throwable;
+use Workflow\Serializers\Y;
+
+class Transformer
+{
+    protected int $traceDepth = PHP_INT_MAX;
+    protected bool $traceArgs = true;
+
+    public function withDepth(int $depth): self
+    {
+        $this->traceDepth = $depth;
+        return $this;
+    }
+
+    public function withoutArgs(): self
+    {
+        $this->traceArgs = false;
+        return $this;
+    }
+
+    /**
+     * @param Throwable $throwable
+     * @return array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]}
+     */
+    public function transform(Throwable $throwable): array
+    {
+        $file = new SplFileObject($throwable->getFile());
+        $iterator = new LimitIterator($file, max(0, $throwable->getLine() - 4), 7);
+
+        $trace = array_slice($throwable->getTrace(), 0, $this->traceDepth);
+        if (!$this->traceArgs) {
+            foreach ($trace as &$entry) {
+                $entry['args'] = [];
+            }
+            unset($entry);
+        }
+
+        $data = [
+            'class' => get_class($throwable),
+            'message' => $throwable->getMessage(),
+            'code' => $throwable->getCode(),
+            'line' => $throwable->getLine(),
+            'file' => $throwable->getFile(),
+            'trace' => collect($trace)
+                ->filter(static fn ($trace) => Y::serializable($trace))
+                ->toArray(),
+            'snippet' => array_slice(iterator_to_array($iterator), 0, 7),
+        ];
+
+        return $data;
+    }
+}

--- a/src/Exceptions/Transformer.php
+++ b/src/Exceptions/Transformer.php
@@ -12,6 +12,7 @@ use Workflow\Serializers\Y;
 class Transformer
 {
     protected int $traceDepth = PHP_INT_MAX;
+
     protected bool $traceArgs = true;
 
     public function withDepth(int $depth): self
@@ -27,7 +28,6 @@ class Transformer
     }
 
     /**
-     * @param Throwable $throwable
      * @return array{class: string, message: string, code: int|string, line: int, file: string, trace: mixed[], snippet: string[]}
      */
     public function transform(Throwable $throwable): array
@@ -36,7 +36,7 @@ class Transformer
         $iterator = new LimitIterator($file, max(0, $throwable->getLine() - 4), 7);
 
         $trace = array_slice($throwable->getTrace(), 0, $this->traceDepth);
-        if (!$this->traceArgs) {
+        if (! $this->traceArgs) {
             foreach ($trace as &$entry) {
                 $entry['args'] = [];
             }

--- a/src/Middleware/WithoutOverlappingMiddleware.php
+++ b/src/Middleware/WithoutOverlappingMiddleware.php
@@ -62,7 +62,7 @@ class WithoutOverlappingMiddleware
     }
 
     /**
-     * @param Workflow | Activity<Workflow, StoredWorkflow<Workflow, null>, mixed> $job
+     * @param Workflow | Activity<Workflow, mixed> $job
      * @param callable $next
      * @return void
      */
@@ -101,7 +101,7 @@ class WithoutOverlappingMiddleware
     }
 
     /**
-     * @param Workflow | Activity<Workflow, StoredWorkflow<Workflow, null>, mixed> $job
+     * @param Workflow | Activity<Workflow, mixed> $job
      * @return bool
      * @throws InvalidArgumentException
      */
@@ -158,7 +158,7 @@ class WithoutOverlappingMiddleware
     }
 
     /**
-     * @param Workflow | Activity<Workflow, StoredWorkflow<Workflow, null>, mixed> $job
+     * @param Workflow | Activity<Workflow, mixed> $job
      * @return void
      * @throws InvalidArgumentException
      */

--- a/src/Middleware/WithoutOverlappingMiddleware.php
+++ b/src/Middleware/WithoutOverlappingMiddleware.php
@@ -11,9 +11,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
-use Psr\SimpleCache\InvalidArgumentException;
 use Workflow\Activity;
-use Workflow\Models\StoredWorkflow;
 use Workflow\Workflow;
 
 class WithoutOverlappingMiddleware
@@ -47,9 +45,6 @@ class WithoutOverlappingMiddleware
     /**
      * @param scalar $workflowId
      * @param self::WORKFLOW|self::ACTIVITY $type
-     * @param int $releaseAfter
-     * @param int $expiresAfter
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function __construct($workflowId, $type, int $releaseAfter = 0, int $expiresAfter = 0)
     {
@@ -64,9 +59,8 @@ class WithoutOverlappingMiddleware
     /**
      * @param Workflow | Activity<Workflow, mixed> $job
      * @param callable $next
-     * @return void
      */
-    public function handle($job, $next) : void
+    public function handle($job, $next): void
     {
         $locked = $this->lock($job);
 
@@ -102,8 +96,6 @@ class WithoutOverlappingMiddleware
 
     /**
      * @param Workflow | Activity<Workflow, mixed> $job
-     * @return bool
-     * @throws InvalidArgumentException
      */
     public function lock($job): bool
     {
@@ -159,8 +151,6 @@ class WithoutOverlappingMiddleware
 
     /**
      * @param Workflow | Activity<Workflow, mixed> $job
-     * @return void
-     * @throws InvalidArgumentException
      */
     public function unlock($job): void
     {
@@ -197,12 +187,8 @@ class WithoutOverlappingMiddleware
 
     /**
      * @template T in int|string[]
-     * @param string $key
      * @param T $expectedValue
      * @param T $newValue
-     * @param int $expiresAfter
-     * @return bool
-     * @throws InvalidArgumentException
      */
     private function compareAndSet(string $key, $expectedValue, $newValue, int $expiresAfter = 0): bool
     {

--- a/src/Middleware/WithoutOverlappingMiddleware.php
+++ b/src/Middleware/WithoutOverlappingMiddleware.php
@@ -94,8 +94,8 @@ class WithoutOverlappingMiddleware
                 if ($workflowSemaphore === 0 && $activitySemaphore === 0) {
                     $locked = $this->compareAndSet(
                         $this->getWorkflowSemaphoreKey(),
-                        (int) $workflowSemaphore,
-                        (int) $workflowSemaphore + 1,
+                        $workflowSemaphore,
+                        $workflowSemaphore + 1,
                         $this->expiresAfter
                     );
                 }
@@ -137,8 +137,8 @@ class WithoutOverlappingMiddleware
                     $workflowSemaphore = (int) $this->cache->get($this->getWorkflowSemaphoreKey(), 0);
                     $unlocked = $this->compareAndSet(
                         $this->getWorkflowSemaphoreKey(),
-                        (int) $workflowSemaphore,
-                        (int) max($workflowSemaphore - 1, 0),
+                        $workflowSemaphore,
+                        max($workflowSemaphore - 1, 0),
                         $this->expiresAfter
                     );
                 }

--- a/src/Middleware/WithoutOverlappingMiddleware.php
+++ b/src/Middleware/WithoutOverlappingMiddleware.php
@@ -72,7 +72,7 @@ class WithoutOverlappingMiddleware
 
         if ($locked) {
             Queue::before(
-                fn (JobProcessing $event) => $this->active = $job->job->getJobId() === $event->job->getJobId()
+                fn (JobProcessing $event) => $this->active = $job->job?->getJobId() === $event->job->getJobId()
             );
             Queue::stopping(fn () => $this->active ? $this->unlock($job) : null);
             try {

--- a/src/Middleware/WorkflowMiddleware.php
+++ b/src/Middleware/WorkflowMiddleware.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Workflow\Middleware;
 
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use LimitIterator;
 use SplFileObject;
+use Workflow\Activity;
 use Workflow\Events\ActivityCompleted;
 use Workflow\Events\ActivityFailed;
 use Workflow\Events\ActivityStarted;
@@ -20,7 +22,7 @@ final class WorkflowMiddleware
     private bool $active = true;
 
     /**
-     * @param Workflow $job
+     * @param Activity<Workflow, mixed> $job
      * @param callable $next
      * @return void
      * @throws \Throwable
@@ -50,7 +52,7 @@ final class WorkflowMiddleware
 
             try {
                 $job->storedWorkflow->toWorkflow()
-                    ->next($job->index, $job->now, $job::class, $result);
+                    ->next($job->index, Carbon::parse($job->now), $job::class, $result);
                 ActivityCompleted::dispatch(
                     $job->storedWorkflow->id,
                     $uuid,

--- a/src/Middleware/WorkflowMiddleware.php
+++ b/src/Middleware/WorkflowMiddleware.php
@@ -13,11 +13,18 @@ use Workflow\Events\ActivityCompleted;
 use Workflow\Events\ActivityFailed;
 use Workflow\Events\ActivityStarted;
 use Workflow\Serializers\Y;
+use Workflow\Workflow;
 
 final class WorkflowMiddleware
 {
-    private $active = true;
+    private bool $active = true;
 
+    /**
+     * @param Workflow $job
+     * @param callable $next
+     * @return void
+     * @throws \Throwable
+     */
     public function handle($job, $next): void
     {
         Queue::stopping(fn () => $this->active ? $job->storedWorkflow->exceptions()

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -6,8 +6,13 @@ namespace Workflow\Models;
 
 use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
+use Workflow\Workflow;
 use Workflow\WorkflowStub;
 
+/**
+ * @template TWorkflow of Workflow
+ * @property class-string<TWorkflow> $class
+ */
 class StoredWorkflow extends Model
 {
     use HasStates;

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\Workflow;
@@ -30,7 +32,7 @@ class StoredWorkflow extends Model
     protected $dateFormat = 'Y-m-d H:i:s.u';
 
     /**
-     * @var array<string, class-string<\Workflow\States\WorkflowStatus>>
+     * @var array<string, class-string<WorkflowStatus>>
      */
     protected $casts = [
         'status' => WorkflowStatus::class,
@@ -41,27 +43,42 @@ class StoredWorkflow extends Model
         return WorkflowStub::fromStoredWorkflow($this);
     }
 
-    public function logs(): \Illuminate\Database\Eloquent\Relations\HasMany
+    /**
+     * @return HasMany<StoredWorkflowLog>
+     */
+    public function logs(): HasMany
     {
         return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class));
     }
 
-    public function signals(): \Illuminate\Database\Eloquent\Relations\HasMany
+    /**
+     * @return HasMany<StoredWorkflowSignal>
+     */
+    public function signals(): HasMany
     {
         return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class));
     }
 
-    public function timers(): \Illuminate\Database\Eloquent\Relations\HasMany
+    /**
+     * @return HasMany<StoredWorkflowTimer>
+     */
+    public function timers(): HasMany
     {
         return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class));
     }
 
-    public function exceptions(): \Illuminate\Database\Eloquent\Relations\HasMany
+    /**
+     * @return HasMany<StoredWorkflowException>
+     */
+    public function exceptions(): HasMany
     {
         return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class));
     }
 
-    public function parents(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    /**
+     * @return BelongsToMany<StoredWorkflow<Workflow>>
+     */
+    public function parents(): BelongsToMany
     {
         return $this->belongsToMany(
             config('workflows.stored_workflow_model', self::class),
@@ -71,7 +88,10 @@ class StoredWorkflow extends Model
         )->withPivot(['parent_index', 'parent_now']);
     }
 
-    public function children(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    /**
+     * @return BelongsToMany<StoredWorkflow<Workflow>>
+     */
+    public function children(): BelongsToMany
     {
         return $this->belongsToMany(
             config('workflows.stored_workflow_model', self::class),

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -11,7 +11,6 @@ use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 /**
  * @template TWorkflow of Workflow
@@ -24,6 +23,7 @@ class StoredWorkflow extends Model
     use HasStates;
 
     protected $table = 'workflows';
+
     protected $guarded = [];
 
     protected $dateFormat = 'Y-m-d H:i:s.u';

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -22,21 +22,11 @@ class StoredWorkflow extends Model
 {
     use HasStates;
 
-    /**
-     * @var string
-     */
     protected $table = 'workflows';
-
-    /**
-     * @var mixed[]
-     */
     protected $guarded = [];
 
     protected $dateFormat = 'Y-m-d H:i:s.u';
 
-    /**
-     * @var array<string, class-string<WorkflowStatus>>
-     */
     protected $casts = [
         'status' => WorkflowStatus::class,
     ];

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -32,12 +32,13 @@ class StoredWorkflow extends Model
     ];
 
     /**
-     * @return WorkflowStub<Workflow>
+     * @return WorkflowStub<TWorkflow>
      */
     public function toWorkflow()
     {
-        /** @var StoredWorkflow<TWorkflow, null> $this */
-        return WorkflowStub::fromStoredWorkflow($this);
+        /** @var self<TWorkflow, null> $this */
+        // @TODO: this seems correct, but phpstan complains. Check if this is a phpstan bug.
+        return WorkflowStub::fromStoredWorkflow($this); // @phpstan-ignore-line
     }
 
     /**

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -31,8 +31,12 @@ class StoredWorkflow extends Model
         'status' => WorkflowStatus::class,
     ];
 
+    /**
+     * @return WorkflowStub<StoredWorkflow<Workflow, null>, Workflow>
+     */
     public function toWorkflow()
     {
+        /** @var StoredWorkflow<TWorkflow, null> $this */
         return WorkflowStub::fromStoredWorkflow($this);
     }
 

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -11,12 +11,13 @@ use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
+use function PHPStan\dumpType;
 
 /**
  * @template TWorkflow of Workflow
- * @template TParentStoredWorkflow of ?self
+ * @template TParentStoredWorkflow of ?true
  * @property class-string<TWorkflow> $class
- * @property (TParentStoredWorkflow is self ? object{parent_index: int, parent_now: Carbon} : null) $parents_pivot
+ * @property (TParentStoredWorkflow is true ? object{parent_index: int, parent_now: Carbon} : null) $parents_pivot
  */
 class StoredWorkflow extends Model
 {
@@ -36,7 +37,6 @@ class StoredWorkflow extends Model
      */
     public function toWorkflow()
     {
-        // @phpstan-ignore-next-line
         return WorkflowStub::fromStoredWorkflow($this);
     }
 
@@ -73,7 +73,7 @@ class StoredWorkflow extends Model
     }
 
     /**
-     * @return BelongsToMany<StoredWorkflow<Workflow, self>>
+     * @return BelongsToMany<StoredWorkflow<Workflow, true>>
      */
     public function parents(): BelongsToMany
     {

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -32,7 +32,7 @@ class StoredWorkflow extends Model
     ];
 
     /**
-     * @return WorkflowStub<StoredWorkflow<Workflow, null>, Workflow>
+     * @return WorkflowStub<Workflow>
      */
     public function toWorkflow()
     {

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -37,7 +37,6 @@ class StoredWorkflow extends Model
     public function toWorkflow()
     {
         /** @var self<TWorkflow, null> $this */
-        // @TODO: this seems correct, but phpstan complains. Check if this is a phpstan bug.
         return WorkflowStub::fromStoredWorkflow($this); // @phpstan-ignore-line
     }
 

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -36,8 +36,8 @@ class StoredWorkflow extends Model
      */
     public function toWorkflow()
     {
-        /** @var self<TWorkflow, null> $this */
-        return WorkflowStub::fromStoredWorkflow($this); // @phpstan-ignore-line
+        // @phpstan-ignore-next-line
+        return WorkflowStub::fromStoredWorkflow($this);
     }
 
     /**

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\ModelStates\HasStates;
@@ -13,7 +14,9 @@ use Workflow\WorkflowStub;
 
 /**
  * @template TWorkflow of Workflow
+ * @template TParentStoredWorkflow of ?self
  * @property class-string<TWorkflow> $class
+ * @property (TParentStoredWorkflow is self ? object{parent_index: int, parent_now: Carbon} : null) $parents_pivot
  */
 class StoredWorkflow extends Model
 {
@@ -76,7 +79,7 @@ class StoredWorkflow extends Model
     }
 
     /**
-     * @return BelongsToMany<StoredWorkflow<Workflow>>
+     * @return BelongsToMany<StoredWorkflow<Workflow, self>>
      */
     public function parents(): BelongsToMany
     {
@@ -85,11 +88,11 @@ class StoredWorkflow extends Model
             config('workflows.workflow_relationships_table', 'workflow_relationships'),
             'child_workflow_id',
             'parent_workflow_id'
-        )->withPivot(['parent_index', 'parent_now']);
+        )->withPivot(['parent_index', 'parent_now'])->as('parents_pivot');
     }
 
     /**
-     * @return BelongsToMany<StoredWorkflow<Workflow>>
+     * @return BelongsToMany<StoredWorkflow<Workflow, null>>
      */
     public function children(): BelongsToMany
     {
@@ -98,6 +101,6 @@ class StoredWorkflow extends Model
             config('workflows.workflow_relationships_table', 'workflow_relationships'),
             'parent_workflow_id',
             'child_workflow_id'
-        )->withPivot(['parent_index', 'parent_now']);
+        )->withPivot(['parent_index', 'parent_now'])->as('children_pivot');
     }
 }

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -8,9 +8,6 @@ use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;
 use Workflow\WorkflowStub;
 
-/**
- * @extends Illuminate\Database\Eloquent\Model
- */
 class StoredWorkflow extends Model
 {
     use HasStates;

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-/**
- * @extends Illuminate\Database\Eloquent\Model
- */
 class StoredWorkflowException extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -8,14 +8,8 @@ class StoredWorkflowException extends Model
 {
     public const UPDATED_AT = null;
 
-    /**
-     * @var string
-     */
     protected $table = 'workflow_exceptions';
 
-    /**
-     * @var mixed[]
-     */
     protected $guarded = [];
 
     protected $dateFormat = 'Y-m-d H:i:s.u';

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -8,21 +8,12 @@ class StoredWorkflowLog extends Model
 {
     public const UPDATED_AT = null;
 
-    /**
-     * @var string
-     */
     protected $table = 'workflow_logs';
 
-    /**
-     * @var mixed[]
-     */
     protected $guarded = [];
 
     protected $dateFormat = 'Y-m-d H:i:s.u';
 
-    /**
-     * @var array<string, class-string<\datetime>>
-     */
     protected $casts = [
         'now' => 'datetime',
     ];

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-/**
- * @extends Illuminate\Database\Eloquent\Model
- */
 class StoredWorkflowLog extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -8,14 +8,8 @@ class StoredWorkflowSignal extends Model
 {
     public const UPDATED_AT = null;
 
-    /**
-     * @var string
-     */
     protected $table = 'workflow_signals';
 
-    /**
-     * @var mixed[]
-     */
     protected $guarded = [];
 
     protected $dateFormat = 'Y-m-d H:i:s.u';

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-/**
- * @extends Illuminate\Database\Eloquent\Model
- */
 class StoredWorkflowSignal extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
-/**
- * @extends Illuminate\Database\Eloquent\Model
- */
 class StoredWorkflowTimer extends Model
 {
     public const UPDATED_AT = null;

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -8,21 +8,10 @@ class StoredWorkflowTimer extends Model
 {
     public const UPDATED_AT = null;
 
-    /**
-     * @var string
-     */
     protected $table = 'workflow_timers';
 
-    /**
-     * @var mixed[]
-     */
     protected $guarded = [];
 
-    protected $dateFormat = 'Y-m-d H:i:s.u';
-
-    /**
-     * @var array<string, class-string<\datetime>>
-     */
     protected $casts = [
         'stop_at' => 'datetime:Y-m-d H:i:s.u',
     ];

--- a/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
+++ b/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateObjectType;
+use PHPStan\Type\Type;
+use Workflow\QueryMethod;
+use Workflow\SignalMethod;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionExtension
+{
+    /** @var array<string, MethodReflection> */
+    private array $cache = [];
+
+    /** @var ReflectionProvider */
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (array_key_exists($classReflection->getCacheKey().'-'.$methodName, $this->cache)) {
+            return true;
+        }
+
+        $methodReflection = $this->findMethod($classReflection, $methodName);
+
+        if ($methodReflection !== null) {
+            $this->cache[$classReflection->getCacheKey().'-'.$methodName] = $methodReflection;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): \PHPStan\Reflection\MethodReflection
+    {
+        return $this->cache[$classReflection->getCacheKey().'-'.$methodName];
+    }
+
+    private function findMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
+    {
+        if ($classReflection->getName() !== WorkflowStub::class) {
+            return null;
+        }
+
+        $workflowType = $classReflection->getActiveTemplateTypeMap()->getType('TWorkflow');
+
+        // Generic type is not specified
+        if ($workflowType === null) {
+            if (! $classReflection->isGeneric() && $classReflection->getParentClass()?->isGeneric()) {
+                $workflowType = $classReflection->getParentClass()->getActiveTemplateTypeMap()->getType('TWorkflow');
+            }
+        }
+
+        if ($workflowType === null) {
+            return null;
+        }
+
+        if ($workflowType instanceof TemplateObjectType) {
+            $workflowType = $workflowType->getBound();
+        }
+
+        if ($workflowType->getObjectClassReflections() !== []) {
+            $workflowReflection = $workflowType->getObjectClassReflections()[0];
+        } else {
+            $workflowReflection = $this->reflectionProvider->getClass(Workflow::class);
+        }
+
+        if ($workflowReflection === null) {
+            return null;
+        }
+
+        if (! $workflowReflection->hasNativeMethod($methodName)) {
+            return null;
+        }
+
+        if (! collect($workflowReflection->getNativeReflection()->getMethod($methodName)->getAttributes())
+            ->contains(static fn ($attribute): bool => in_array($attribute->getName(), [SignalMethod::class, QueryMethod::class])))
+        {
+            return null;
+        }
+
+        $methodReflection = $workflowReflection->getNativeMethod($methodName);
+
+        return new class($classReflection, $methodName, $methodReflection) implements MethodReflection
+        {
+            /** @var ClassReflection */
+            private $classReflection;
+
+            /** @var string */
+            private $methodName;
+
+            /** @var MethodReflection */
+            private $methodReflection;
+
+            public function __construct(ClassReflection $classReflection, string $methodName, MethodReflection $methodReflection)
+            {
+                $this->classReflection = $classReflection;
+                $this->methodName = $methodName;
+                $this->methodReflection = $methodReflection;
+            }
+
+            public function getDeclaringClass(): ClassReflection
+            {
+                return $this->classReflection;
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): ?string
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->methodName;
+            }
+
+            public function getPrototype(): ClassMemberReflection
+            {
+                return $this;
+            }
+
+            public function getVariants(): array
+            {
+                return $this->methodReflection->getVariants();
+            }
+
+            public function isDeprecated(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): ?string
+            {
+                return null;
+            }
+
+            public function isFinal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function isInternal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getThrowType(): ?Type
+            {
+                return null;
+            }
+
+            public function hasSideEffects(): TrinaryLogic
+            {
+                return TrinaryLogic::createYes();
+            }
+        };
+    }
+}

--- a/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
+++ b/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
@@ -63,7 +63,7 @@ class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionEx
 
         // Generic type is not specified
         if ($workflowType === null) {
-            if (! $classReflection->isGeneric() && $classReflection->getParentClass()?->isGeneric()) {
+            if (! $classReflection->isGeneric() && ($classReflection->getParentClass()?->isGeneric() ?? false)) {
                 $workflowType = $classReflection->getParentClass()->getActiveTemplateTypeMap()->getType('TWorkflow');
             }
         }

--- a/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
+++ b/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
@@ -19,28 +19,28 @@ use Workflow\WorkflowStub;
 
 class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionExtension
 {
-    /** @var array<string, MethodReflection> */
+    /**
+     * @var array<string, MethodReflection>
+     */
     private array $cache = [];
 
-    /** @var ReflectionProvider */
     private ReflectionProvider $reflectionProvider;
 
-    public function __construct(
-        ReflectionProvider $reflectionProvider
-    ) {
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
         $this->reflectionProvider = $reflectionProvider;
     }
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if (array_key_exists($classReflection->getCacheKey().'-'.$methodName, $this->cache)) {
+        if (array_key_exists($classReflection->getCacheKey() . '-' . $methodName, $this->cache)) {
             return true;
         }
 
         $methodReflection = $this->findMethod($classReflection, $methodName);
 
         if ($methodReflection !== null) {
-            $this->cache[$classReflection->getCacheKey().'-'.$methodName] = $methodReflection;
+            $this->cache[$classReflection->getCacheKey() . '-' . $methodName] = $methodReflection;
 
             return true;
         }
@@ -48,9 +48,11 @@ class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionEx
         return false;
     }
 
-    public function getMethod(ClassReflection $classReflection, string $methodName): \PHPStan\Reflection\MethodReflection
-    {
-        return $this->cache[$classReflection->getCacheKey().'-'.$methodName];
+    public function getMethod(
+        ClassReflection $classReflection,
+        string $methodName
+    ): \PHPStan\Reflection\MethodReflection {
+        return $this->cache[$classReflection->getCacheKey() . '-' . $methodName];
     }
 
     private function findMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
@@ -59,12 +61,15 @@ class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionEx
             return null;
         }
 
-        $workflowType = $classReflection->getActiveTemplateTypeMap()->getType('TWorkflow');
+        $workflowType = $classReflection->getActiveTemplateTypeMap()
+            ->getType('TWorkflow');
 
         // Generic type is not specified
         if ($workflowType === null) {
             if (! $classReflection->isGeneric() && ($classReflection->getParentClass()?->isGeneric() ?? false)) {
-                $workflowType = $classReflection->getParentClass()->getActiveTemplateTypeMap()->getType('TWorkflow');
+                $workflowType = $classReflection->getParentClass()
+                    ->getActiveTemplateTypeMap()
+                    ->getType('TWorkflow');
             }
         }
 
@@ -87,26 +92,38 @@ class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionEx
         }
 
         if (! collect($workflowReflection->getNativeReflection()->getMethod($methodName)->getAttributes())
-            ->contains(static fn ($attribute): bool => in_array($attribute->getName(), [SignalMethod::class, QueryMethod::class])))
-        {
+            ->contains(
+                static fn ($attribute): bool => in_array($attribute->getName(), [
+                    SignalMethod::class,
+                    QueryMethod::class,
+                ], true)
+            )) {
             return null;
         }
 
         $methodReflection = $workflowReflection->getNativeMethod($methodName);
 
-        return new class($classReflection, $methodName, $methodReflection) implements MethodReflection
-        {
-            /** @var ClassReflection */
+        return new class($classReflection, $methodName, $methodReflection) implements MethodReflection {
+            /**
+             * @var ClassReflection
+             */
             private $classReflection;
 
-            /** @var string */
+            /**
+             * @var string
+             */
             private $methodName;
 
-            /** @var MethodReflection */
+            /**
+             * @var MethodReflection
+             */
             private $methodReflection;
 
-            public function __construct(ClassReflection $classReflection, string $methodName, MethodReflection $methodReflection)
-            {
+            public function __construct(
+                ClassReflection $classReflection,
+                string $methodName,
+                MethodReflection $methodReflection
+            ) {
                 $this->classReflection = $classReflection;
                 $this->methodName = $methodName;
                 $this->methodReflection = $methodReflection;

--- a/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
+++ b/src/PHPStan/WorkflowStubDynamicCallMethodExtension.php
@@ -82,10 +82,6 @@ class WorkflowStubDynamicCallMethodExtension implements MethodsClassReflectionEx
             $workflowReflection = $this->reflectionProvider->getClass(Workflow::class);
         }
 
-        if ($workflowReflection === null) {
-            return null;
-        }
-
         if (! $workflowReflection->hasNativeMethod($methodName)) {
             return null;
         }

--- a/src/PHPStan/extension.neon
+++ b/src/PHPStan/extension.neon
@@ -1,0 +1,5 @@
+services:
+  -
+    class: \Workflow\PHPStan\WorkflowStubDynamicCallMethodExtension
+    tags:
+      - phpstan.broker.methodsClassReflectionExtension

--- a/src/Providers/WorkflowServiceProvider.php
+++ b/src/Providers/WorkflowServiceProvider.php
@@ -33,7 +33,7 @@ final class WorkflowServiceProvider extends ServiceProvider
 
         SerializableClosure::setSecretKey(config('app.key'));
 
-        if (config('workflows.monitor', false)) {
+        if (config('workflows.monitor', false) === true) {
             Event::listen(WorkflowStarted::class, [MonitorWorkflowStarted::class, 'handle']);
             Event::listen(WorkflowCompleted::class, [MonitorWorkflowCompleted::class, 'handle']);
             Event::listen(WorkflowFailed::class, [MonitorWorkflowFailed::class, 'handle']);

--- a/src/Serializers/SerializerInterface.php
+++ b/src/Serializers/SerializerInterface.php
@@ -10,7 +10,7 @@ interface SerializerInterface
 
     public static function decode(string $data): string;
 
-    public static function serialize($data): string;
+    public static function serialize(mixed $data): string;
 
-    public static function unserialize(string $data);
+    public static function unserialize(string $data): mixed;
 }

--- a/src/Serializers/Y.php
+++ b/src/Serializers/Y.php
@@ -62,11 +62,6 @@ final class Y implements SerializerInterface
         }
     }
 
-    /**
-     * @template T
-     * @param T $data
-     * @return (T is Throwable ? array{class: string, message: string, code: int|int, line: int, file: string, trace: mixed[]} : T)
-     */
     public static function serializeModels(mixed $data): mixed
     {
         if (is_array($data)) {

--- a/src/Serializers/Y.php
+++ b/src/Serializers/Y.php
@@ -12,7 +12,7 @@ final class Y implements SerializerInterface
 {
     use SerializesAndRestoresModelIdentifiers;
 
-    private static $instance = null;
+    private static self $instance;
 
     private function __construct()
     {
@@ -20,10 +20,7 @@ final class Y implements SerializerInterface
 
     public static function getInstance(): self
     {
-        if (self::$instance === null) {
-            self::$instance = new self();
-        }
-        return self::$instance;
+        return self::$instance ??= new self();
     }
 
     public static function encode(string $data): string
@@ -55,7 +52,7 @@ final class Y implements SerializerInterface
         return $output;
     }
 
-    public static function serializable($data): bool
+    public static function serializable(mixed $data): bool
     {
         try {
             serialize($data);
@@ -65,7 +62,12 @@ final class Y implements SerializerInterface
         }
     }
 
-    public static function serializeModels($data)
+    /**
+     * @template T
+     * @param T $data
+     * @return (T is Throwable ? array{class: string, message: string, code: int|int, line: int, file: string, trace: mixed[]} : T)
+     */
+    public static function serializeModels(mixed $data): mixed
     {
         if (is_array($data)) {
             $self = self::getInstance();
@@ -87,7 +89,7 @@ final class Y implements SerializerInterface
         return $data;
     }
 
-    public static function unserializeModels($data)
+    public static function unserializeModels(mixed $data): mixed
     {
         if (is_array($data)) {
             $self = self::getInstance();
@@ -98,14 +100,14 @@ final class Y implements SerializerInterface
         return $data;
     }
 
-    public static function serialize($data): string
+    public static function serialize(mixed $data): string
     {
         SerializableClosure::setSecretKey(config('app.key'));
         $data = self::serializeModels($data);
         return self::encode(serialize(new SerializableClosure(static fn () => $data)));
     }
 
-    public static function unserialize(string $data)
+    public static function unserialize(string $data): mixed
     {
         SerializableClosure::setSecretKey(config('app.key'));
         $unserialized = unserialize(self::decode($data));

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Workflow;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -28,8 +27,6 @@ final class Signal implements ShouldBeEncrypted, ShouldQueue
 
     /**
      * @param StoredWorkflow<Workflow, null> $storedWorkflow
-     * @param string|null $connection
-     * @param string|null $queue
      */
     public function __construct(
         public StoredWorkflow $storedWorkflow,
@@ -44,7 +41,6 @@ final class Signal implements ShouldBeEncrypted, ShouldQueue
 
     /**
      * @return mixed[]
-     * @throws BindingResolutionException
      */
     public function middleware()
     {

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -26,6 +26,11 @@ final class Signal implements ShouldBeEncrypted, ShouldQueue
 
     public int $maxExceptions = 0;
 
+    /**
+     * @param StoredWorkflow<Workflow, null> $storedWorkflow
+     * @param string|null $connection
+     * @param string|null $queue
+     */
     public function __construct(
         public StoredWorkflow $storedWorkflow,
         ?string $connection = null,

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -7,6 +7,7 @@ namespace Workflow\Traits;
 use Carbon\CarbonInterval;
 use Illuminate\Database\QueryException;
 use React\Promise\PromiseInterface;
+use function PHPStan\dumpType;
 use function React\Promise\resolve;
 use Workflow\Serializers\Y;
 use Workflow\Signal;

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -14,7 +14,12 @@ use Workflow\Signal;
 
 trait AwaitWithTimeouts
 {
-    public static function awaitWithTimeout(int|string $seconds, $condition): PromiseInterface
+    /**
+     * @param int|string $seconds
+     * @param callable():bool $condition
+     * @return PromiseInterface<bool>
+     */
+    public static function awaitWithTimeout(int|string $seconds, callable $condition): PromiseInterface
     {
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -21,13 +21,17 @@ trait AwaitWithTimeouts
      */
     public static function awaitWithTimeout(int|string $seconds, callable $condition): PromiseInterface
     {
+        if (self::$context === null) {
+            throw new \RuntimeException('ActivityStub::awaitWithTimeout() must be called within a workflow');
+        }
+
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)
             ->first();
 
         if ($log !== null) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve($log->result !== null ? Y::unserialize($log->result) : null);
         }
 
         if (is_string($seconds)) {
@@ -53,7 +57,7 @@ trait AwaitWithTimeouts
 
                     if ($log !== null) {
                         ++self::$context->index;
-                        return resolve(Y::unserialize($log->result));
+                        return resolve($log->result !== null ? Y::unserialize($log->result) : null);
                     }
                 }
             }

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -14,7 +14,7 @@ use Workflow\Signal;
 
 trait AwaitWithTimeouts
 {
-    public static function awaitWithTimeout($seconds, $condition): PromiseInterface
+    public static function awaitWithTimeout(int|string $seconds, $condition): PromiseInterface
     {
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)
@@ -26,7 +26,7 @@ trait AwaitWithTimeouts
         }
 
         if (is_string($seconds)) {
-            $seconds = CarbonInterval::fromString($seconds)->totalSeconds;
+            $seconds = (int) CarbonInterval::fromString($seconds)->totalSeconds;
         }
 
         $result = $condition();

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -25,7 +25,7 @@ trait AwaitWithTimeouts
             ->whereIndex(self::$context->index)
             ->first();
 
-        if ($log) {
+        if ($log !== null) {
             ++self::$context->index;
             return resolve(Y::unserialize($log->result));
         }
@@ -51,7 +51,7 @@ trait AwaitWithTimeouts
                         ->whereIndex(self::$context->index)
                         ->first();
 
-                    if ($log) {
+                    if ($log !== null) {
                         ++self::$context->index;
                         return resolve(Y::unserialize($log->result));
                     }

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -7,7 +7,6 @@ namespace Workflow\Traits;
 use Carbon\CarbonInterval;
 use Illuminate\Database\QueryException;
 use React\Promise\PromiseInterface;
-use function PHPStan\dumpType;
 use function React\Promise\resolve;
 use Workflow\Serializers\Y;
 use Workflow\Signal;
@@ -15,7 +14,6 @@ use Workflow\Signal;
 trait AwaitWithTimeouts
 {
     /**
-     * @param int|string $seconds
      * @param callable():bool $condition
      * @return PromiseInterface<bool>
      */

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -19,13 +19,17 @@ trait Awaits
      */
     public static function await(callable $condition): PromiseInterface
     {
+        if (self::$context === null) {
+            throw new \RuntimeException('ActivityStub::await() must be called within a workflow');
+        }
+
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)
             ->first();
 
         if ($log !== null) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve($log->result !== null ? Y::unserialize($log->result) : null);
         }
 
         $result = $condition();
@@ -47,7 +51,7 @@ trait Awaits
 
                     if ($log !== null) {
                         ++self::$context->index;
-                        return resolve(Y::unserialize($log->result));
+                        return resolve($log->result !== null ? Y::unserialize($log->result) : null);
                     }
                 }
             }

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -23,7 +23,7 @@ trait Awaits
             ->whereIndex(self::$context->index)
             ->first();
 
-        if ($log) {
+        if ($log !== null) {
             ++self::$context->index;
             return resolve(Y::unserialize($log->result));
         }
@@ -45,7 +45,7 @@ trait Awaits
                         ->whereIndex(self::$context->index)
                         ->first();
 
-                    if ($log) {
+                    if ($log !== null) {
                         ++self::$context->index;
                         return resolve(Y::unserialize($log->result));
                     }

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -13,7 +13,11 @@ use Workflow\Signal;
 
 trait Awaits
 {
-    public static function await($condition): PromiseInterface
+    /**
+     * @param callable():bool $condition
+     * @return PromiseInterface<bool>
+     */
+    public static function await(callable $condition): PromiseInterface
     {
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)

--- a/src/Traits/Fakes.php
+++ b/src/Traits/Fakes.php
@@ -98,7 +98,7 @@ trait Fakes
                 return collect();
             }
 
-            $callback = $callback ?: static fn () => true;
+            $callback = $callback ?? static fn () => true;
 
             return collect($dispatched[$workflowOrActivity])->filter(
                 static fn ($arguments) => $callback(...$arguments)

--- a/src/Traits/Fakes.php
+++ b/src/Traits/Fakes.php
@@ -6,6 +6,7 @@ namespace Workflow\Traits;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use function PHPStan\dumpType;
 
 /**
  * @method static void mock(string $class, mixed $result)
@@ -103,7 +104,9 @@ trait Fakes
         });
 
         static::macro('dispatched', static function (string $workflowOrActivity, callable|null $callback = null): Collection {
+            /** @var Collection<string, mixed[]> $dispatched */
             $dispatched = App::make(self::$DISPATCHED_LIST);
+
             if (! isset($dispatched[$workflowOrActivity])) {
                 return collect();
             }

--- a/src/Traits/Fakes.php
+++ b/src/Traits/Fakes.php
@@ -7,6 +7,16 @@ namespace Workflow\Traits;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 
+/**
+ * @method static void mock(string $class, mixed $result)
+ * @method static array<string, mixed[]> mocks()
+ * @method static void assertNothingDispatched()
+ * @method static void assertDispatched(string $workflowOrActivity, callable|int|null $callback = null)
+ * @method static void assertNotDispatched(string $workflowOrActivity, callable|null $callback = null)
+ * @method static void assertDispatchedTimes(string $workflowOrActivity, int $times = 1)
+ * @method static void recordDispatched(string $class, mixed $arguments)
+ * @method static Collection<int, mixed[]> dispatched(string $workflowOrActivity, callable|null $callback = null)
+ */
 trait Fakes
 {
     protected static string $DISPATCHED_LIST = 'workflow.dispatched';
@@ -32,7 +42,7 @@ trait Fakes
             return App::make(static::$MOCKS_LIST);
         });
 
-        static::macro('mock', static function ($class, $result) {
+        static::macro('mock', static function (string $class, mixed $result) {
             $mocks = static::mocks();
 
             App::bind(static::$MOCKS_LIST, static function () use ($mocks, $class, $result) {
@@ -41,7 +51,7 @@ trait Fakes
             });
         });
 
-        static::macro('recordDispatched', static function ($class, $arguments) {
+        static::macro('recordDispatched', static function (string $class, mixed $arguments) {
             $dispatched = App::make(static::$DISPATCHED_LIST);
 
             App::bind(static::$DISPATCHED_LIST, static function () use ($dispatched, $class, $arguments) {
@@ -55,7 +65,7 @@ trait Fakes
             });
         });
 
-        static::macro('assertDispatched', static function (string $workflowOrActivity, $callback = null) {
+        static::macro('assertDispatched', static function (string $workflowOrActivity, callable|int|null $callback = null) {
             if (is_int($callback)) {
                 self::assertDispatchedTimes($workflowOrActivity, $callback);
                 return;
@@ -77,7 +87,7 @@ trait Fakes
             );
         });
 
-        static::macro('assertNotDispatched', static function (string $workflowOrActivity, $callback = null) {
+        static::macro('assertNotDispatched', static function (string $workflowOrActivity, callable|null $callback = null) {
             \PHPUnit\Framework\Assert::assertTrue(
                 self::dispatched($workflowOrActivity, $callback)->count() === 0,
                 "The unexpected [{$workflowOrActivity}] workflow/activity was dispatched."
@@ -92,7 +102,7 @@ trait Fakes
             );
         });
 
-        static::macro('dispatched', static function (string $workflowOrActivity, $callback = null): Collection {
+        static::macro('dispatched', static function (string $workflowOrActivity, callable|null $callback = null): Collection {
             $dispatched = App::make(self::$DISPATCHED_LIST);
             if (! isset($dispatched[$workflowOrActivity])) {
                 return collect();

--- a/src/Traits/FetchesMonitorAuth.php
+++ b/src/Traits/FetchesMonitorAuth.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Http;
 
 trait FetchesMonitorAuth
 {
+    /**
+     * @return mixed[]
+     */
     protected function auth(): array
     {
         return Cache::remember('workflows.monitor_auth', 3600, static function () {

--- a/src/Traits/Sagas.php
+++ b/src/Traits/Sagas.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Workflow\Traits;
 
+use Generator;
 use Throwable;
 use Workflow\ActivityStub;
 
 trait Sagas
 {
+    /**
+     * @var callable[]
+     */
     private array $compensations = [];
 
     private bool $parallelCompensation = false;
@@ -36,7 +40,11 @@ trait Sagas
         return $this;
     }
 
-    public function compensate()
+    /**
+     * @return Generator<int, mixed, mixed, void>
+     * @throws Throwable
+     */
+    public function compensate(): Generator
     {
         if ($this->parallelCompensation) {
             $compensations = [];

--- a/src/Traits/Sagas.php
+++ b/src/Traits/Sagas.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Workflow\Traits;
 
-use Generator;
 use Closure;
-use React\Promise\PromiseInterface;
+use Generator;
 use Throwable;
 use Workflow\ActivityStub;
-use function PHPStan\dumpType;
 
 trait Sagas
 {
@@ -36,9 +34,6 @@ trait Sagas
         return $this;
     }
 
-    /**
-     * @param Closure $compensation
-     */
     public function addCompensation(Closure $compensation): self
     {
         $this->compensations[] = $compensation;
@@ -48,7 +43,6 @@ trait Sagas
 
     /**
      * @return Generator<int, mixed, mixed, void>
-     * @throws Throwable
      */
     public function compensate(): Generator
     {
@@ -60,7 +54,8 @@ trait Sagas
             yield ActivityStub::all($compensations);
         } else {
             for (end($this->compensations); key($this->compensations) !== null; prev($this->compensations)) {
-                if (false === ($currentCompensation = current($this->compensations))) {
+                $currentCompensation = current($this->compensations);
+                if ($currentCompensation === false) {
                     continue;
                 }
                 try {

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -11,7 +11,12 @@ use Workflow\Serializers\Y;
 
 trait SideEffects
 {
-    public static function sideEffect($callable): PromiseInterface
+    /**
+     * @template T
+     * @param callable(): T $callable
+     * @return PromiseInterface<T>
+     */
+    public static function sideEffect(callable $callable): PromiseInterface
     {
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -22,7 +22,7 @@ trait SideEffects
             ->whereIndex(self::$context->index)
             ->first();
 
-        if ($log) {
+        if ($log !== null) {
             ++self::$context->index;
             return resolve(Y::unserialize($log->result));
         }
@@ -43,7 +43,7 @@ trait SideEffects
                     ->whereIndex(self::$context->index)
                     ->first();
 
-                if ($log) {
+                if ($log !== null) {
                     ++self::$context->index;
                     return resolve(Y::unserialize($log->result));
                 }

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -18,13 +18,17 @@ trait SideEffects
      */
     public static function sideEffect(callable $callable): PromiseInterface
     {
+        if (self::$context === null) {
+            throw new \RuntimeException('ActivityStub::sideEffect() must be called within a workflow');
+        }
+
         $log = self::$context->storedWorkflow->logs()
             ->whereIndex(self::$context->index)
             ->first();
 
         if ($log !== null) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve($log->result !== null ? Y::unserialize($log->result) : null);
         }
 
         $result = $callable();
@@ -45,7 +49,7 @@ trait SideEffects
 
                 if ($log !== null) {
                     ++self::$context->index;
-                    return resolve(Y::unserialize($log->result));
+                    return resolve($log->result !== null ? Y::unserialize($log->result) : null);
                 }
             }
         }

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -8,7 +8,6 @@ use Carbon\CarbonInterval;
 use Illuminate\Database\QueryException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
-use function PHPStan\dumpType;
 use function React\Promise\resolve;
 use Workflow\Serializers\Y;
 use Workflow\Signal;

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -32,7 +32,7 @@ trait Timers
             ->whereIndex(self::$context->index)
             ->first();
 
-        if ($log) {
+        if ($log !== null) {
             ++self::$context->index;
             return resolve(Y::unserialize($log->result));
         }

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -14,10 +14,13 @@ use Workflow\Signal;
 
 trait Timers
 {
-    public static function timer($seconds): PromiseInterface
+    /**
+     * @return PromiseInterface<bool>
+     */
+    public static function timer(string|int $seconds): PromiseInterface
     {
         if (is_string($seconds)) {
-            $seconds = CarbonInterval::fromString($seconds)->totalSeconds;
+            $seconds = (int) CarbonInterval::fromString($seconds)->totalSeconds;
         }
 
         if ($seconds <= 0) {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -81,7 +81,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
         $parentWorkflow = $this->storedWorkflow->parents()
             ->first();
 
-        if ($parentWorkflow) {
+        if ($parentWorkflow !== null) {
             return [
                 new WithoutOverlappingMiddleware($parentWorkflow->id, WithoutOverlappingMiddleware::ACTIVITY, 0, 15),
             ];
@@ -136,10 +136,10 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                 $this->{$signal->method}(...Y::unserialize($signal->arguments));
             });
 
-        if ($parentWorkflow) {
+        if ($parentWorkflow !== null) {
             $this->now = Carbon::parse($parentWorkflow->pivot->parent_now);
         } else {
-            $this->now = $log ? $log->now : Carbon::now();
+            $this->now = $log !== null ? $log->now : Carbon::now();
         }
 
         WorkflowStub::setContext([
@@ -162,7 +162,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                 ->whereIndex($this->index)
                 ->first();
 
-            if ($log) {
+            if ($log !== null) {
                 $this->storedWorkflow
                     ->signals()
                     ->where('created_at', '>', $log->created_at->format('Y-m-d H:i:s.u'))
@@ -176,7 +176,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
             $log = $nextLog;
 
-            $this->now = $log ? $log->now : Carbon::now();
+            $this->now = $log !== null ? $log->now : Carbon::now();
 
             WorkflowStub::setContext([
                 'storedWorkflow' => $this->storedWorkflow,
@@ -225,7 +225,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                     ->format('Y-m-d\TH:i:s.u\Z')
             );
 
-            if ($parentWorkflow) {
+            if ($parentWorkflow !== null) {
                 $parentWorkflow->toWorkflow()
                     ->next($parentWorkflow->pivot->parent_index, $this->now, $this->storedWorkflow->class, $return);
             }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -149,7 +149,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             'replaying' => $this->replaying,
         ]);
 
-        $this->coroutine = $this->{'execute'}(...$this->resolveClassMethodDependencies(
+        $this->coroutine = $this->execute(...$this->resolveClassMethodDependencies(
             $this->arguments,
             $this,
             'execute'

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -26,6 +26,7 @@ use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowRunningStatus;
 use Workflow\States\WorkflowWaitingStatus;
 use Workflow\Traits\Sagas;
+use function PHPStan\dumpType;
 
 class Workflow implements ShouldBeEncrypted, ShouldQueue
 {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -65,13 +65,9 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
     ) {
         $this->arguments = $arguments;
 
-        if (property_exists($this, 'connection')) {
-            $this->onConnection($this->connection);
-        }
+        $this->onConnection($this->connection ?? null);
 
-        if (property_exists($this, 'queue')) {
-            $this->onQueue($this->queue);
-        }
+        $this->onQueue($this->queue ?? null);
 
         $this->afterCommit = true;
     }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -52,6 +52,11 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
     public bool $replaying = false;
 
+    /**
+     * The container property is needed in the @see RouteDependencyResolverTrait
+     * which in turn is used to dynamically resolve the "execute" method parameters.
+     * @phpstan-ignore-next-line
+     */
     private Container $container;
 
     public function __construct(

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -140,13 +140,6 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             });
 
         if ($parentWorkflow !== null) {
-            if ($parentWorkflow->parents_pivot?->parent_now === null) {
-                /**
-                 * this should not happen, but if it does, we do not want to fall back to Carbon::now()
-                 * as this could lead to inconsistencies in the workflow execution
-                 */
-                throw new RuntimeException('The parent workflow exists, but the parent_now column in the pivot table is empty.');
-            }
             $this->now = Carbon::parse($parentWorkflow->parents_pivot->parent_now);
         } else {
             $this->now = $log !== null ? $log->now : Carbon::now();

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -48,6 +48,9 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
      */
     public $arguments;
 
+    /** @var string  */
+    public $key = '';
+
     /**
      * @var Generator<int, mixed, mixed, mixed>
      */
@@ -244,9 +247,13 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 
             $this->storedWorkflow->status->transitionTo(WorkflowCompletedStatus::class);
 
+            if (false === ($encodedReturn = json_encode($return))) {
+                throw new Exception('Could not encode return.');
+            }
+            
             WorkflowCompleted::dispatch(
                 $this->storedWorkflow->id,
-                json_encode($return),
+                $encodedReturn,
                 now()
                     ->format('Y-m-d\TH:i:s.u\Z')
             );

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -254,7 +254,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             try {
                 $return = $this->coroutine->getReturn();
             } catch (Throwable $th) {
-                throw new Exception('Workflow failed.');
+                throw new Exception('Workflow failed.', 0, $th);
             }
 
             $this->storedWorkflow->output = Y::serialize($return);

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -25,6 +25,9 @@ use Workflow\Traits\Fakes;
 use Workflow\Traits\SideEffects;
 use Workflow\Traits\Timers;
 
+/**
+ * @template TStoredWorkflow of StoredWorkflow
+ */
 final class WorkflowStub
 {
     use Awaits;
@@ -36,6 +39,9 @@ final class WorkflowStub
 
     private static ?\stdClass $context = null;
 
+    /**
+     * @param TStoredWorkflow $storedWorkflow
+     */
     private function __construct(
         protected $storedWorkflow
     ) {
@@ -288,11 +294,16 @@ final class WorkflowStub
 
         $this->storedWorkflow->status->transitionTo(WorkflowPendingStatus::class);
 
-        $dispatch = static::faked() ? 'dispatchSync' : 'dispatch';
-
-        $this->storedWorkflow->class::$dispatch(
-            $this->storedWorkflow,
-            ...Y::unserialize($this->storedWorkflow->arguments)
-        );
+        if (self::faked()) {
+            $this->storedWorkflow->class::dispatchSync(
+                $this->storedWorkflow,
+                ...Y::unserialize($this->storedWorkflow->arguments)
+            );
+        } else {
+            $this->storedWorkflow->class::dispatch(
+                $this->storedWorkflow,
+                ...Y::unserialize($this->storedWorkflow->arguments)
+            );
+        }
     }
 }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -26,7 +26,6 @@ use Workflow\Traits\SideEffects;
 use Workflow\Traits\Timers;
 
 /**
- * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
  * @template TWorkflow of Workflow
  */
 final class WorkflowStub
@@ -41,7 +40,7 @@ final class WorkflowStub
     private static ?\stdClass $context = null;
 
     /**
-     * @param TStoredWorkflow $storedWorkflow
+     * @param StoredWorkflow $storedWorkflow
      */
     private function __construct(
         protected $storedWorkflow
@@ -108,7 +107,7 @@ final class WorkflowStub
     /**
      * @template TWorkflowClass of Workflow
      * @param class-string<TWorkflowClass> $class
-     * @return self<TStoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
+     * @return self<StoredWorkflow<TWorkflowClass>, TWorkflowClass>
      */
     public static function make($class): self
     {
@@ -120,7 +119,7 @@ final class WorkflowStub
             throw new \RuntimeException('StoredWorkflow model must extend ' . StoredWorkflow::class);
         }
 
-        /** @var TStoredWorkflow<TWorkflowClass, null> $storedWorkflow */
+        /** @var StoredWorkflow<TWorkflowClass, null> $storedWorkflow */
         return new self($storedWorkflow);
     }
 
@@ -133,8 +132,8 @@ final class WorkflowStub
 
     /**
      * @template TWorkflowClass of Workflow
-     * @param TStoredWorkflow<TWorkflowClass, null> $storedWorkflow
-     * @return self<TStoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
+     * @param StoredWorkflow<TWorkflowClass, null> $storedWorkflow
+     * @return self<StoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
      */
     public static function fromStoredWorkflow(StoredWorkflow $storedWorkflow): self
     {

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -9,13 +9,10 @@ use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use LimitIterator;
 use ReflectionClass;
 use RuntimeException;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
-use SplFileObject;
 use stdClass;
 use Throwable;
 use Workflow\Events\WorkflowFailed;
@@ -304,10 +301,7 @@ final class WorkflowStub
             $this->storedWorkflow->exceptions()
                 ->create([
                     'class' => $this->storedWorkflow->class,
-                    'exception' => Y::serialize(
-                        app(Transformer::class)
-                             ->transform($exception)
-                    ),
+                    'exception' => Y::serialize(app(Transformer::class) ->transform($exception)),
                 ]);
         } catch (QueryException) {
             // already logged
@@ -315,10 +309,7 @@ final class WorkflowStub
 
         $this->storedWorkflow->status->transitionTo(WorkflowFailedStatus::class);
 
-        $encodedException = json_encode(
-            app(Transformer::class)
-                ->transform($exception)
-        );
+        $encodedException = json_encode(app(Transformer::class) ->transform($exception));
         if ($encodedException === false) {
             throw new RuntimeException('Could not encode exception.');
         }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -133,7 +133,7 @@ final class WorkflowStub
     /**
      * @template TWorkflowClass of Workflow
      * @param StoredWorkflow<TWorkflowClass, null> $storedWorkflow
-     * @return self<StoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
+     * @return self<TWorkflowClass>
      */
     public static function fromStoredWorkflow(StoredWorkflow $storedWorkflow): self
     {

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -24,9 +24,11 @@ use Workflow\Traits\AwaitWithTimeouts;
 use Workflow\Traits\Fakes;
 use Workflow\Traits\SideEffects;
 use Workflow\Traits\Timers;
+use function PHPStan\dumpType;
 
 /**
- * @template TStoredWorkflow of StoredWorkflow
+ * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
+ * @template TWorkflow of Workflow
  */
 final class WorkflowStub
 {
@@ -69,7 +71,7 @@ final class WorkflowStub
 
             $this->storedWorkflow->toWorkflow();
 
-            if (static::faked()) {
+            if (self::faked()) {
                 $this->resume();
                 return;
             }
@@ -104,7 +106,12 @@ final class WorkflowStub
         return Arr::get((new ReflectionClass(self::$context->storedWorkflow->class))->getDefaultProperties(), 'queue');
     }
 
-    public static function make($class): static
+    /**
+     * @template TWorkflowClass of Workflow
+     * @param class-string<TWorkflowClass> $class
+     * @return static<TStoredWorkflow, TWorkflowClass>
+     */
+    public static function make($class): self
     {
         $storedWorkflow = config('workflows.stored_workflow_model', StoredWorkflow::class)::create([
             'class' => $class,
@@ -115,7 +122,7 @@ final class WorkflowStub
 
     public static function load($id)
     {
-        return static::fromStoredWorkflow(
+        return self::fromStoredWorkflow(
             config('workflows.stored_workflow_model', StoredWorkflow::class)::findOrFail($id)
         );
     }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -24,7 +24,6 @@ use Workflow\Traits\AwaitWithTimeouts;
 use Workflow\Traits\Fakes;
 use Workflow\Traits\SideEffects;
 use Workflow\Traits\Timers;
-use function PHPStan\dumpType;
 
 /**
  * @template TStoredWorkflow of StoredWorkflow<TWorkflow, null>
@@ -109,7 +108,7 @@ final class WorkflowStub
     /**
      * @template TWorkflowClass of Workflow
      * @param class-string<TWorkflowClass> $class
-     * @return static<TStoredWorkflow, TWorkflowClass>
+     * @return self<TStoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
      */
     public static function make($class): self
     {
@@ -117,6 +116,11 @@ final class WorkflowStub
             'class' => $class,
         ]);
 
+        if (!$storedWorkflow instanceof StoredWorkflow) {
+            throw new \RuntimeException('StoredWorkflow model must extend ' . StoredWorkflow::class);
+        }
+
+        /** @var TStoredWorkflow<TWorkflowClass, null> $storedWorkflow */
         return new self($storedWorkflow);
     }
 
@@ -127,7 +131,12 @@ final class WorkflowStub
         );
     }
 
-    public static function fromStoredWorkflow(StoredWorkflow $storedWorkflow): static
+    /**
+     * @template TWorkflowClass of Workflow
+     * @param TStoredWorkflow<TWorkflowClass, null> $storedWorkflow
+     * @return self<TStoredWorkflow<TWorkflowClass, null>, TWorkflowClass>
+     */
+    public static function fromStoredWorkflow(StoredWorkflow $storedWorkflow): self
     {
         return new self($storedWorkflow);
     }

--- a/src/migrations/2024_02_05_093552_change_exception_column_to_longtext.php
+++ b/src/migrations/2024_02_05_093552_change_exception_column_to_longtext.php
@@ -6,11 +6,12 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     public function up(): void
     {
-        Schema::table('workflow_exceptions', function (Blueprint $table) {
-            $table->longText('exception')->change();
+        Schema::table('workflow_exceptions', static function (Blueprint $table) {
+            $table->longText('exception')
+                ->change();
         });
     }
 };

--- a/src/migrations/2024_02_05_093552_change_exception_column_to_longtext.php
+++ b/src/migrations/2024_02_05_093552_change_exception_column_to_longtext.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('workflow_exceptions', function (Blueprint $table) {
+            $table->longText('exception')->change();
+        });
+    }
+};

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestAsyncWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\AsyncWorkflow;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/AsyncWorkflowTest.php
+++ b/tests/Feature/AsyncWorkflowTest.php
@@ -6,11 +6,12 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestAsyncWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\AsyncWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class AsyncWorkflowTest extends TestCase
+final class AsyncWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testAsyncWorkflow(): void
     {

--- a/tests/Feature/AwaitWithTimeoutWorkflowTest.php
+++ b/tests/Feature/AwaitWithTimeoutWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestAwaitWithTimeoutWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/AwaitWithTimeoutWorkflowTest.php
+++ b/tests/Feature/AwaitWithTimeoutWorkflowTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestAwaitWithTimeoutWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class AwaitWithTimeoutWorkflowTest extends TestCase
+final class AwaitWithTimeoutWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/AwaitWorkflowTest.php
+++ b/tests/Feature/AwaitWorkflowTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class AwaitWorkflowTest extends TestCase
+final class AwaitWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/AwaitWorkflowTest.php
+++ b/tests/Feature/AwaitWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestAwaitWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/ConcurrentWorkflowTest.php
+++ b/tests/Feature/ConcurrentWorkflowTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestConcurrentWorkflow;
 use Tests\Fixtures\TestOtherActivity;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/ConcurrentWorkflowTest.php
+++ b/tests/Feature/ConcurrentWorkflowTest.php
@@ -8,10 +8,11 @@ use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestConcurrentWorkflow;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class ConcurrentWorkflowTest extends TestCase
+final class ConcurrentWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/DispatchWorkflowInTransactionTest.php
+++ b/tests/Feature/DispatchWorkflowInTransactionTest.php
@@ -7,10 +7,11 @@ namespace Tests\Feature;
 use Illuminate\Support\Facades\DB;
 use Tests\Fixtures\TestSimpleWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class DispatchWorkflowInTransactionTest extends TestCase
+final class DispatchWorkflowInTransactionTest extends TestCaseRequiringWorkers
 {
     public function testRaceCondition(): void
     {

--- a/tests/Feature/DispatchWorkflowInTransactionTest.php
+++ b/tests/Feature/DispatchWorkflowInTransactionTest.php
@@ -6,7 +6,6 @@ namespace Tests\Feature;
 
 use Illuminate\Support\Facades\DB;
 use Tests\Fixtures\TestSimpleWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/DispatchWorkflowInTransactionTest.php
+++ b/tests/Feature/DispatchWorkflowInTransactionTest.php
@@ -9,7 +9,6 @@ use Tests\Fixtures\TestSimpleWorkflow;
 use Tests\TestCase;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 final class DispatchWorkflowInTransactionTest extends TestCase
 {

--- a/tests/Feature/DispatchWorkflowInTransactionTest.php
+++ b/tests/Feature/DispatchWorkflowInTransactionTest.php
@@ -9,6 +9,7 @@ use Tests\Fixtures\TestSimpleWorkflow;
 use Tests\TestCase;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
+use function PHPStan\dumpType;
 
 final class DispatchWorkflowInTransactionTest extends TestCase
 {
@@ -37,6 +38,7 @@ final class DispatchWorkflowInTransactionTest extends TestCase
             sleep(3);
         });
 
+        $this->assertNotNull($workflow);
         /**
          * the workflow stays in the pending state as the transaction was not committed
          * when the worker was told to process the workflow

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestExceptionWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -6,11 +6,12 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class ExceptionWorkflowTest extends TestCase
+final class ExceptionWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testRetry(): void
     {

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -22,7 +22,7 @@ final class ExceptionWorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        if ($workflow->exceptions()->first()) {
+        if ($workflow->exceptions()->first() !== null) {
             $this->assertSame('failed', Y::unserialize($workflow->exceptions()->first()->exception)['message']);
         }
     }

--- a/tests/Feature/FailingWorkflowTest.php
+++ b/tests/Feature/FailingWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestFailingWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;

--- a/tests/Feature/FailingWorkflowTest.php
+++ b/tests/Feature/FailingWorkflowTest.php
@@ -6,11 +6,12 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestFailingWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
 
-final class FailingWorkflowTest extends TestCase
+final class FailingWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testRetry(): void
     {

--- a/tests/Feature/HeartbeatWorkflowTest.php
+++ b/tests/Feature/HeartbeatWorkflowTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestHeartbeatWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class HeartbeatWorkflowTest extends TestCase
+final class HeartbeatWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testHeartbeat(): void
     {

--- a/tests/Feature/HeartbeatWorkflowTest.php
+++ b/tests/Feature/HeartbeatWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestHeartbeatWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -13,12 +13,13 @@ use Tests\Fixtures\TestParentExceptionWorkflow;
 use Tests\Fixtures\TestParentTimerWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\AsyncWorkflow;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
 
-final class ParentWorkflowTest extends TestCase
+final class ParentWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/ParentWorkflowTest.php
+++ b/tests/Feature/ParentWorkflowTest.php
@@ -12,7 +12,6 @@ use Tests\Fixtures\TestParentAsyncWorkflow;
 use Tests\Fixtures\TestParentExceptionWorkflow;
 use Tests\Fixtures\TestParentTimerWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\AsyncWorkflow;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/RetriesWorkflowTest.php
+++ b/tests/Feature/RetriesWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestRetriesWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\WorkflowStub;
 

--- a/tests/Feature/RetriesWorkflowTest.php
+++ b/tests/Feature/RetriesWorkflowTest.php
@@ -6,9 +6,10 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestRetriesWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\WorkflowStub;
 
-final class RetriesWorkflowTest extends TestCase
+final class RetriesWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testRetries(): void
     {

--- a/tests/Feature/SagaWorkflowTest.php
+++ b/tests/Feature/SagaWorkflowTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestSagaWorkflow;
 use Tests\Fixtures\TestUndoActivity;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\Exception;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/SagaWorkflowTest.php
+++ b/tests/Feature/SagaWorkflowTest.php
@@ -8,12 +8,13 @@ use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestSagaWorkflow;
 use Tests\Fixtures\TestUndoActivity;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\Exception;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
 
-final class SagaWorkflowTest extends TestCase
+final class SagaWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/SideEffectWorkflowTest.php
+++ b/tests/Feature/SideEffectWorkflowTest.php
@@ -8,10 +8,11 @@ use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestSideEffectWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class SideEffectWorkflowTest extends TestCase
+final class SideEffectWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Feature/SideEffectWorkflowTest.php
+++ b/tests/Feature/SideEffectWorkflowTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestSideEffectWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/StateMachineWorkflowTest.php
+++ b/tests/Feature/StateMachineWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestStateMachineWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/StateMachineWorkflowTest.php
+++ b/tests/Feature/StateMachineWorkflowTest.php
@@ -6,11 +6,12 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestStateMachineWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class StateMachineWorkflowTest extends TestCase
+final class StateMachineWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testApproved(): void
     {

--- a/tests/Feature/TimeoutWorkflowTest.php
+++ b/tests/Feature/TimeoutWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestTimeoutWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\WorkflowStub;
 

--- a/tests/Feature/TimeoutWorkflowTest.php
+++ b/tests/Feature/TimeoutWorkflowTest.php
@@ -6,9 +6,10 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestTimeoutWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\WorkflowStub;
 
-final class TimeoutWorkflowTest extends TestCase
+final class TimeoutWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testTimeout(): void
     {

--- a/tests/Feature/TimerWorkflowTest.php
+++ b/tests/Feature/TimerWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\TestTimerWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;

--- a/tests/Feature/TimerWorkflowTest.php
+++ b/tests/Feature/TimerWorkflowTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\TestTimerWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class TimerWorkflowTest extends TestCase
+final class TimerWorkflowTest extends TestCaseRequiringWorkers
 {
     public function testTimerWorkflow(): void
     {

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringWorkers;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;

--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -8,11 +8,12 @@ use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringWorkers;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
 
-final class WorkflowTest extends TestCase
+final class WorkflowTest extends TestCaseRequiringWorkers
 {
     public function testCompleted(): void
     {

--- a/tests/Fixtures/StateMachine.php
+++ b/tests/Fixtures/StateMachine.php
@@ -8,18 +8,24 @@ use Exception;
 
 class StateMachine
 {
-    private $states = [];
+    /**
+     * @var string[]
+     */
+    private array $states = [];
 
-    private $transitions = [];
+    /**
+     * @var array<string, array{from: string, to: string}>
+     */
+    private array $transitions = [];
 
-    private $currentState;
+    private string $currentState;
 
-    public function addState($state)
+    public function addState(string $state) : void
     {
         $this->states[] = $state;
     }
 
-    public function addTransition($action, $fromState, $toState)
+    public function addTransition(string $action, string $fromState, string $toState): void
     {
         $this->transitions[$action] = [
             'from' => $fromState,
@@ -27,19 +33,19 @@ class StateMachine
         ];
     }
 
-    public function initialize()
+    public function initialize(): void
     {
         if (count($this->states) > 0) {
             $this->currentState = $this->states[0];
         }
     }
 
-    public function getCurrentState()
+    public function getCurrentState(): string
     {
         return $this->currentState;
     }
 
-    public function apply($action)
+    public function apply(string $action): void
     {
         if (isset($this->transitions[$action]) && $this->transitions[$action]['from'] === $this->currentState) {
             $this->currentState = $this->transitions[$action]['to'];

--- a/tests/Fixtures/StateMachine.php
+++ b/tests/Fixtures/StateMachine.php
@@ -20,7 +20,7 @@ class StateMachine
 
     private string $currentState;
 
-    public function addState(string $state) : void
+    public function addState(string $state): void
     {
         $this->states[] = $state;
     }

--- a/tests/Fixtures/TestActivity.php
+++ b/tests/Fixtures/TestActivity.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 class TestActivity extends Activity
 {
-    public function execute(Application $app)
+    public function execute(Application $app): string
     {
         assert($app->runningInConsole());
 

--- a/tests/Fixtures/TestActivity.php
+++ b/tests/Fixtures/TestActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
 use Workflow\Workflow;

--- a/tests/Fixtures/TestAsyncWorkflow.php
+++ b/tests/Fixtures/TestAsyncWorkflow.php
@@ -4,23 +4,26 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 final class TestAsyncWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
-        $results = yield ActivityStub::async(static function (Application $app) {
-            assert($app->runningInConsole());
+        $results = yield ActivityStub::async(
+            static function (Application $app) {
+                assert($app->runningInConsole());
 
-            $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+                $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
-            $result = yield ActivityStub::make(TestActivity::class);
+                $result = yield ActivityStub::make(TestActivity::class);
 
-            return [$otherResult, $result];
-        });
+                return [$otherResult, $result];
+            }
+        );
 
         $otherResult = $results[0];
         $result = $results[1];

--- a/tests/Fixtures/TestAwaitWithTimeoutWorkflow.php
+++ b/tests/Fixtures/TestAwaitWithTimeoutWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
 
 final class TestAwaitWithTimeoutWorkflow extends Workflow
 {
-    public function execute($shouldTimeout = false)
+    public function execute(bool $shouldTimeout = false): Generator
     {
         $result = yield WorkflowStub::awaitWithTimeout(5, static fn (): bool => ! $shouldTimeout);
 

--- a/tests/Fixtures/TestAwaitWorkflow.php
+++ b/tests/Fixtures/TestAwaitWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\SignalMethod;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
@@ -18,7 +19,7 @@ final class TestAwaitWorkflow extends Workflow
         $this->canceled = true;
     }
 
-    public function execute()
+    public function execute(): Generator
     {
         yield WorkflowStub::await(fn (): bool => $this->canceled);
 

--- a/tests/Fixtures/TestBadConnectionWorkflow.php
+++ b/tests/Fixtures/TestBadConnectionWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\ActivityStub;
 use Workflow\QueryMethod;
@@ -31,7 +32,7 @@ class TestBadConnectionWorkflow extends Workflow
         return $this->canceled;
     }
 
-    public function execute(Application $app, $shouldAssert = false)
+    public function execute(Application $app, bool $shouldAssert = false): Generator
     {
         assert($app->runningInConsole());
 

--- a/tests/Fixtures/TestBadConnectionWorkflow.php
+++ b/tests/Fixtures/TestBadConnectionWorkflow.php
@@ -42,7 +42,7 @@ class TestBadConnectionWorkflow extends Workflow
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
         if ($shouldAssert) {
-            assert(! $this->canceled);
+            assert(! $this->canceled); // @phpstan-ignore-line
         }
 
         yield WorkflowStub::await(fn (): bool => $this->canceled);

--- a/tests/Fixtures/TestChildExceptionWorkflow.php
+++ b/tests/Fixtures/TestChildExceptionWorkflow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
@@ -14,7 +15,7 @@ class TestChildExceptionWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute($shouldThrow = false)
+    public function execute(bool $shouldThrow = false): Generator
     {
         if ($shouldThrow) {
             throw new Exception('failed');

--- a/tests/Fixtures/TestChildTimerWorkflow.php
+++ b/tests/Fixtures/TestChildTimerWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
@@ -14,7 +15,7 @@ class TestChildTimerWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute($seconds = 1)
+    public function execute(int $seconds = 1): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestChildWorkflow.php
+++ b/tests/Fixtures/TestChildWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 class TestChildWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestConcurrentWorkflow.php
+++ b/tests/Fixtures/TestConcurrentWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 final class TestConcurrentWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         $otherResultPromise = ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestExceptionActivity.php
+++ b/tests/Fixtures/TestExceptionActivity.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 final class TestExceptionActivity extends Activity
 {
-    public function execute()
+    public function execute(): string
     {
         if ($this->attempts() === 1) {
             throw new Exception('failed');

--- a/tests/Fixtures/TestExceptionActivity.php
+++ b/tests/Fixtures/TestExceptionActivity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestExceptionWorkflow.php
+++ b/tests/Fixtures/TestExceptionWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 final class TestExceptionWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestFailingWorkflow.php
+++ b/tests/Fixtures/TestFailingWorkflow.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 final class TestFailingWorkflow extends Workflow
 {
-    public function execute($shouldFail = false)
+    public function execute(bool $shouldFail = false): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestHeartbeatActivity.php
+++ b/tests/Fixtures/TestHeartbeatActivity.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 final class TestHeartbeatActivity extends Activity
 {
     public $timeout = 5;
 
-    public function execute()
+    public function execute(): string
     {
         for ($i = 0; $i < 10; ++$i) {
             sleep(1);

--- a/tests/Fixtures/TestHeartbeatActivity.php
+++ b/tests/Fixtures/TestHeartbeatActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestHeartbeatWorkflow.php
+++ b/tests/Fixtures/TestHeartbeatWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 final class TestHeartbeatWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestInvalidActivity.php
+++ b/tests/Fixtures/TestInvalidActivity.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, mixed>
+ */
 class TestInvalidActivity extends Activity
 {
 }

--- a/tests/Fixtures/TestOtherActivity.php
+++ b/tests/Fixtures/TestOtherActivity.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 final class TestOtherActivity extends Activity
 {
-    public function execute(Application $app, $string)
+    public function execute(Application $app, mixed $string): mixed
     {
         assert($app->runningInConsole());
 

--- a/tests/Fixtures/TestOtherActivity.php
+++ b/tests/Fixtures/TestOtherActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
 use Workflow\Workflow;

--- a/tests/Fixtures/TestParentAsyncWorkflow.php
+++ b/tests/Fixtures/TestParentAsyncWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\ChildWorkflowStub;
 use Workflow\Workflow;
@@ -14,7 +15,7 @@ class TestParentAsyncWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute()
+    public function execute(): Generator
     {
         $results = yield ActivityStub::async(static function () {
             $otherResult = yield ChildWorkflowStub::make(TestChildWorkflow::class);

--- a/tests/Fixtures/TestParentExceptionWorkflow.php
+++ b/tests/Fixtures/TestParentExceptionWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\ChildWorkflowStub;
 use Workflow\Workflow;
@@ -14,7 +15,7 @@ class TestParentExceptionWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute($shouldThrow = false)
+    public function execute(bool $shouldThrow = false): Generator
     {
         $otherResult = yield ChildWorkflowStub::make(TestChildExceptionWorkflow::class, $shouldThrow);
 

--- a/tests/Fixtures/TestParentTimerWorkflow.php
+++ b/tests/Fixtures/TestParentTimerWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\ChildWorkflowStub;
 use Workflow\Workflow;
@@ -14,7 +15,7 @@ class TestParentTimerWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute($seconds = 1)
+    public function execute(int $seconds = 1): Generator
     {
         $otherResult = yield ChildWorkflowStub::make(TestChildTimerWorkflow::class, $seconds);
 

--- a/tests/Fixtures/TestParentWorkflow.php
+++ b/tests/Fixtures/TestParentWorkflow.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\ChildWorkflowStub;
 use Workflow\Workflow;
 
 class TestParentWorkflow extends Workflow
 {
-    public function execute()
+    public function execute(): Generator
     {
         $otherResult = yield ChildWorkflowStub::make(TestChildWorkflow::class);
 

--- a/tests/Fixtures/TestRetriesActivity.php
+++ b/tests/Fixtures/TestRetriesActivity.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, void>
+ */
 final class TestRetriesActivity extends Activity
 {
     public $tries = 3;
 
-    public function execute()
+    public function execute(): void
     {
         throw new Exception('failed');
     }

--- a/tests/Fixtures/TestRetriesActivity.php
+++ b/tests/Fixtures/TestRetriesActivity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestRetriesWorkflow.php
+++ b/tests/Fixtures/TestRetriesWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
@@ -13,7 +14,7 @@ class TestRetriesWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute()
+    public function execute(): Generator
     {
         yield ActivityStub::make(TestRetriesActivity::class);
     }

--- a/tests/Fixtures/TestSagaActivity.php
+++ b/tests/Fixtures/TestSagaActivity.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, void>
+ */
 final class TestSagaActivity extends Activity
 {
     public $tries = 1;
 
-    public function execute()
+    public function execute(): void
     {
         throw new Exception('saga');
     }

--- a/tests/Fixtures/TestSagaActivity.php
+++ b/tests/Fixtures/TestSagaActivity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestSagaUndoActivity.php
+++ b/tests/Fixtures/TestSagaUndoActivity.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 final class TestSagaUndoActivity extends Activity
 {
-    public function execute()
+    public function execute(): string
     {
         return 'saga_undo_activity';
     }

--- a/tests/Fixtures/TestSagaUndoActivity.php
+++ b/tests/Fixtures/TestSagaUndoActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestSagaWorkflow.php
+++ b/tests/Fixtures/TestSagaWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
 class TestSagaWorkflow extends Workflow
 {
-    public function execute($shouldThrow = false)
+    public function execute(bool $shouldThrow = false): Generator
     {
         try {
             yield ActivityStub::make(TestActivity::class);

--- a/tests/Fixtures/TestSideEffectWorkflow.php
+++ b/tests/Fixtures/TestSideEffectWorkflow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Exception;
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
@@ -15,7 +16,7 @@ class TestSideEffectWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute()
+    public function execute(): Generator
     {
         $sideEffect = yield WorkflowStub::sideEffect(static fn () => random_int(PHP_INT_MIN, PHP_INT_MAX));
 

--- a/tests/Fixtures/TestSimpleWorkflow.php
+++ b/tests/Fixtures/TestSimpleWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
@@ -13,7 +14,7 @@ class TestSimpleWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute()
+    public function execute(): Generator
     {
         $result = yield ActivityStub::make(TestActivity::class);
 

--- a/tests/Fixtures/TestStateMachineWorkflow.php
+++ b/tests/Fixtures/TestStateMachineWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Models\StoredWorkflow;
 use Workflow\SignalMethod;
 use Workflow\Workflow;
@@ -15,7 +16,7 @@ class TestStateMachineWorkflow extends Workflow
 
     public $queue = 'default';
 
-    private $stateMachine;
+    private StateMachine $stateMachine;
 
     public function __construct(
         public StoredWorkflow $storedWorkflow,
@@ -38,39 +39,39 @@ class TestStateMachineWorkflow extends Workflow
     }
 
     #[SignalMethod]
-    public function submit()
+    public function submit(): void
     {
         $this->stateMachine->apply('submit');
     }
 
     #[SignalMethod]
-    public function approve()
+    public function approve(): void
     {
         $this->stateMachine->apply('approve');
     }
 
     #[SignalMethod]
-    public function deny()
+    public function deny(): void
     {
         $this->stateMachine->apply('deny');
     }
 
-    public function isSubmitted()
+    public function isSubmitted(): bool
     {
         return $this->stateMachine->getCurrentState() === 'submitted';
     }
 
-    public function isApproved()
+    public function isApproved(): bool
     {
         return $this->stateMachine->getCurrentState() === 'approved';
     }
 
-    public function isDenied()
+    public function isDenied(): bool
     {
         return $this->stateMachine->getCurrentState() === 'denied';
     }
 
-    public function execute()
+    public function execute(): Generator
     {
         yield WorkflowStub::await(fn () => $this->isSubmitted());
 

--- a/tests/Fixtures/TestTimeTravelWorkflow.php
+++ b/tests/Fixtures/TestTimeTravelWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\QueryMethod;
 use Workflow\SignalMethod;
@@ -26,7 +27,7 @@ class TestTimeTravelWorkflow extends Workflow
         return $this->canceled;
     }
 
-    public function execute()
+    public function execute(): Generator
     {
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestTimeoutActivity.php
+++ b/tests/Fixtures/TestTimeoutActivity.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, void>
+ */
 final class TestTimeoutActivity extends Activity
 {
     public $timeout = 3;
 
     public $tries = 1;
 
-    public function execute()
+    public function execute(): void
     {
         sleep(PHP_INT_MAX);
     }

--- a/tests/Fixtures/TestTimeoutActivity.php
+++ b/tests/Fixtures/TestTimeoutActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestTimeoutWorkflow.php
+++ b/tests/Fixtures/TestTimeoutWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\ActivityStub;
 use Workflow\Workflow;
 
@@ -13,7 +14,7 @@ class TestTimeoutWorkflow extends Workflow
 
     public $queue = 'default';
 
-    public function execute()
+    public function execute(): Generator
     {
         yield ActivityStub::make(TestTimeoutActivity::class);
     }

--- a/tests/Fixtures/TestTimerWorkflow.php
+++ b/tests/Fixtures/TestTimerWorkflow.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Workflow;
 use Workflow\WorkflowStub;
 
 final class TestTimerWorkflow extends Workflow
 {
-    public function execute($seconds = 1)
+    public function execute(int $seconds = 1): Generator
     {
         yield WorkflowStub::timer($seconds);
 

--- a/tests/Fixtures/TestUndoActivity.php
+++ b/tests/Fixtures/TestUndoActivity.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Workflow\Activity;
+use Workflow\Workflow;
 
+/**
+ * @template TWorkflow of Workflow
+ * @extends Activity<TWorkflow, string>
+ */
 class TestUndoActivity extends Activity
 {
-    public function execute()
+    public function execute(): string
     {
         return 'undo_activity';
     }

--- a/tests/Fixtures/TestUndoActivity.php
+++ b/tests/Fixtures/TestUndoActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Generator;
 use Workflow\Activity;
 use Workflow\Workflow;
 

--- a/tests/Fixtures/TestWorkflow.php
+++ b/tests/Fixtures/TestWorkflow.php
@@ -42,7 +42,7 @@ class TestWorkflow extends Workflow
         $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
 
         if ($shouldAssert) {
-            assert(! $this->canceled);
+            assert(! $this->canceled); // @phpstan-ignore-line
         }
 
         yield WorkflowStub::await(fn (): bool => $this->canceled);

--- a/tests/Fixtures/TestWorkflow.php
+++ b/tests/Fixtures/TestWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use Generator;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\ActivityStub;
 use Workflow\QueryMethod;
@@ -31,7 +32,7 @@ class TestWorkflow extends Workflow
         return $this->canceled;
     }
 
-    public function execute(Application $app, $shouldAssert = false)
+    public function execute(Application $app, bool $shouldAssert = false): Generator
     {
         assert($app->runningInConsole());
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,10 @@ abstract class TestCase extends BaseTestCase
 {
     public const NUMBER_OF_WORKERS = 2;
 
-    private static $workers = [];
+    /**
+     * @var list<Process>
+     */
+    private static array $workers = [];
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,42 +6,12 @@ namespace Tests;
 
 use Dotenv\Dotenv;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use Symfony\Component\Process\Process;
 
 abstract class TestCase extends BaseTestCase
 {
-    public const NUMBER_OF_WORKERS = 2;
-
-    /**
-     * @var list<Process>
-     */
-    private static array $workers = [];
-
     public static function setUpBeforeClass(): void
     {
         Dotenv::createImmutable(__DIR__ . '/..')->safeLoad();
-
-        for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
-            self::$workers[$i] = new Process(['php', 'artisan', 'queue:work'], null, $_ENV);
-            self::$workers[$i]->start();
-        }
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        foreach (self::$workers as $worker) {
-            $worker->stop();
-        }
-    }
-
-    protected function defineDatabaseMigrations()
-    {
-        $this->artisan('migrate:fresh', [
-            '--path' => dirname(__DIR__) . '/src/migrations',
-            '--realpath' => true,
-        ]);
-
-        $this->loadLaravelMigrations();
     }
 
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,7 +22,7 @@ abstract class TestCase extends BaseTestCase
         Dotenv::createImmutable(__DIR__ . '/..')->safeLoad();
 
         for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
-            self::$workers[$i] = new Process(['php', 'artisan', 'queue:work']);
+            self::$workers[$i] = new Process(['php', 'artisan', 'queue:work'], null, $_ENV);
             self::$workers[$i]->start();
         }
     }

--- a/tests/TestCaseRequiringDatabase.php
+++ b/tests/TestCaseRequiringDatabase.php
@@ -14,6 +14,7 @@ abstract class TestCaseRequiringDatabase extends TestCase
             '--path' => dirname(__DIR__) . '/src/migrations',
             '--realpath' => true,
         ]);
+        $this->artisan('schema:dump');
 
         $this->loadLaravelMigrations();
     }

--- a/tests/TestCaseRequiringDatabase.php
+++ b/tests/TestCaseRequiringDatabase.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Tests;
 
-
 abstract class TestCaseRequiringDatabase extends TestCase
 {
-
     protected function defineDatabaseMigrations()
     {
         $this->artisan('migrate:fresh', [

--- a/tests/TestCaseRequiringDatabase.php
+++ b/tests/TestCaseRequiringDatabase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+
+abstract class TestCaseRequiringDatabase extends TestCase
+{
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->artisan('migrate:fresh', [
+            '--path' => dirname(__DIR__) . '/src/migrations',
+            '--realpath' => true,
+        ]);
+
+        $this->loadLaravelMigrations();
+    }
+}

--- a/tests/TestCaseRequiringWorkers.php
+++ b/tests/TestCaseRequiringWorkers.php
@@ -11,7 +11,7 @@ abstract class TestCaseRequiringWorkers extends TestCaseRequiringDatabase
     public const NUMBER_OF_WORKERS = 2;
 
     /**
-     * @var Process
+     * @var Process[]
      */
     private static array $workers = [];
 

--- a/tests/TestCaseRequiringWorkers.php
+++ b/tests/TestCaseRequiringWorkers.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Dotenv\Dotenv;
+use Symfony\Component\Process\Process;
+
+abstract class TestCaseRequiringWorkers extends TestCaseRequiringDatabase
+{
+    public const NUMBER_OF_WORKERS = 2;
+
+    /**
+     * @var Process
+     */
+    private static array $workers = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
+            self::$workers[$i] = new Process(['php', 'artisan', 'queue:work'], null, $_ENV);
+            self::$workers[$i]->start();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$workers as $worker) {
+            $worker->stop();
+        }
+    }
+}

--- a/tests/TestCaseRequiringWorkers.php
+++ b/tests/TestCaseRequiringWorkers.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Dotenv\Dotenv;
 use Symfony\Component\Process\Process;
 
 abstract class TestCaseRequiringWorkers extends TestCaseRequiringDatabase

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\ActivityStub;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Models\StoredWorkflowLog;
@@ -15,7 +16,7 @@ use Workflow\Serializers\Y;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
-final class ActivityStubTest extends TestCase
+final class ActivityStubTest extends TestCaseRequiringDatabase
 {
     public function testStoresResult(): void
     {

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -7,7 +7,6 @@ namespace Tests\Unit;
 use Exception;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\ActivityStub;
 use Workflow\Models\StoredWorkflow;

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -10,6 +10,7 @@ use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\ActivityStub;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
@@ -40,7 +41,11 @@ final class ActivityStubTest extends TestCase
             'index' => 0,
             'class' => TestActivity::class,
         ]);
-        $this->assertSame('activity', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+
+        $this->assertSame('activity', Y::unserialize($firstLog->result));
     }
 
     public function testLoadsStoredResult(): void

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -14,7 +14,6 @@ use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 final class ActivityStubTest extends TestCase
 {
@@ -41,7 +40,8 @@ final class ActivityStubTest extends TestCase
             'index' => 0,
             'class' => TestActivity::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
 
@@ -102,10 +102,7 @@ final class ActivityStubTest extends TestCase
                 $result = $value;
             });
 
-        /**
-         * @phpstan-ignore-next-line
-         */
-        $this->assertSame('test', $result['message']);
+        $this->assertSame('test', $result['message']); //@phpstan-ignore-line
     }
 
     public function testAll(): void

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -22,7 +22,9 @@ final class ActivityTest extends TestCase
     public function testActivity(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
-        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), 'other');
+        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(
+            $workflow->id()
+        ), 'other');
         $activity->timeout = 1;
         $activity->heartbeat();
 
@@ -87,7 +89,9 @@ final class ActivityTest extends TestCase
             'class' => TestOtherActivity::class,
             'result' => Y::serialize('other'),
         ]);
-        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), 'other');
+        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(
+            $workflow->id()
+        ), 'other');
         $activity->timeout = 1;
         $activity->heartbeat();
 

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -10,7 +10,6 @@ use Tests\Fixtures\TestExceptionActivity;
 use Tests\Fixtures\TestInvalidActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -11,13 +11,14 @@ use Tests\Fixtures\TestInvalidActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowCreatedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
 
-final class ActivityTest extends TestCase
+final class ActivityTest extends TestCaseRequiringDatabase
 {
     public function testActivity(): void
     {

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -22,15 +22,13 @@ final class ActivityTest extends TestCase
     public function testActivity(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
-        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), [
-            'other',
-        ]);
+        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), 'other');
         $activity->timeout = 1;
         $activity->heartbeat();
 
         $result = $activity->handle();
 
-        $this->assertSame(['other'], $result);
+        $this->assertSame('other', $result);
         $this->assertSame([1, 2, 5, 10, 15, 30, 60, 120], $activity->backoff());
         $this->assertSame($workflow->id(), $activity->workflowId());
         $this->assertSame($activity->timeout, pcntl_alarm(0));
@@ -89,9 +87,7 @@ final class ActivityTest extends TestCase
             'class' => TestOtherActivity::class,
             'result' => Y::serialize('other'),
         ]);
-        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), [
-            'other',
-        ]);
+        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), 'other');
         $activity->timeout = 1;
         $activity->heartbeat();
 

--- a/tests/Unit/AsyncWorkflowTest.php
+++ b/tests/Unit/AsyncWorkflowTest.php
@@ -6,10 +6,11 @@ namespace Tests\Unit;
 
 use Laravel\SerializableClosure\SerializableClosure;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\AsyncWorkflow;
 use Workflow\WorkflowStub;
 
-final class AsyncWorkflowTest extends TestCase
+final class AsyncWorkflowTest extends TestCaseRequiringDatabase
 {
     public function testWorkflow(): void
     {

--- a/tests/Unit/AsyncWorkflowTest.php
+++ b/tests/Unit/AsyncWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Laravel\SerializableClosure\SerializableClosure;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\AsyncWorkflow;
 use Workflow\WorkflowStub;

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -7,13 +7,14 @@ namespace Tests\Unit;
 use Tests\Fixtures\TestChildWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\ChildWorkflowStub;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
-final class ChildWorkflowStubTest extends TestCase
+final class ChildWorkflowStubTest extends TestCaseRequiringDatabase
 {
     public function testStoresResult(): void
     {

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit;
 
 use Tests\Fixtures\TestChildWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\ChildWorkflowStub;
 use Workflow\Models\StoredWorkflow;

--- a/tests/Unit/Commands/ActivityMakeCommandTest.php
+++ b/tests/Unit/Commands/ActivityMakeCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Commands;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
@@ -23,13 +24,13 @@ final class ActivityMakeCommandTest extends TestCase
             'root' => app_path(),
         ]);
 
+        $filesystem->delete($file);
+        $filesystem->deleteDirectory(self::FOLDER);
+
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        if (($command = $this->artisan('make:activity ' . self::ACTIVITY)) instanceof PendingCommand) {
-            $command->assertSuccessful();
-        }
-
+        Artisan::call('make:activity', ['name' => self::ACTIVITY]);
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Commands/ActivityMakeCommandTest.php
+++ b/tests/Unit/Commands/ActivityMakeCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 final class ActivityMakeCommandTest extends TestCase
@@ -25,7 +26,10 @@ final class ActivityMakeCommandTest extends TestCase
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        $this->artisan('make:activity ' . self::ACTIVITY)->assertSuccessful();
+        if (($command = $this->artisan('make:activity ' . self::ACTIVITY)) instanceof PendingCommand) {
+            $command->assertSuccessful();
+        }
+
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Commands/ActivityMakeCommandTest.php
+++ b/tests/Unit/Commands/ActivityMakeCommandTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 final class ActivityMakeCommandTest extends TestCase
@@ -30,7 +29,9 @@ final class ActivityMakeCommandTest extends TestCase
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        Artisan::call('make:activity', ['name' => self::ACTIVITY]);
+        Artisan::call('make:activity', [
+            'name' => self::ACTIVITY,
+        ]);
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Commands/WorkflowMakeCommandTest.php
+++ b/tests/Unit/Commands/WorkflowMakeCommandTest.php
@@ -26,7 +26,9 @@ final class WorkflowMakeCommandTest extends TestCase
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        Artisan::call('make:activity', ['name' => self::WORKFLOW]);
+        Artisan::call('make:activity', [
+            'name' => self::WORKFLOW,
+        ]);
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Commands/WorkflowMakeCommandTest.php
+++ b/tests/Unit/Commands/WorkflowMakeCommandTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Commands;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 final class WorkflowMakeCommandTest extends TestCase
@@ -26,9 +26,7 @@ final class WorkflowMakeCommandTest extends TestCase
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        if (($command = $this->artisan('make:workflow ' . self::WORKFLOW)) instanceof PendingCommand) {
-            $command->assertSuccessful();
-        }
+        Artisan::call('make:activity', ['name' => self::WORKFLOW]);
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Commands/WorkflowMakeCommandTest.php
+++ b/tests/Unit/Commands/WorkflowMakeCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 final class WorkflowMakeCommandTest extends TestCase
@@ -25,7 +26,9 @@ final class WorkflowMakeCommandTest extends TestCase
         $this->assertFalse($filesystem->exists(self::FOLDER));
         $this->assertFalse($filesystem->exists($file));
 
-        $this->artisan('make:workflow ' . self::WORKFLOW)->assertSuccessful();
+        if (($command = $this->artisan('make:workflow ' . self::WORKFLOW)) instanceof PendingCommand) {
+            $command->assertSuccessful();
+        }
 
         $this->assertTrue($filesystem->exists($file));
 

--- a/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
+++ b/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Middleware;
 
 use Illuminate\Support\Facades\Cache;
+use Mockery;
 use Mockery\MockInterface;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
@@ -28,16 +29,16 @@ final class WithoutOverlappingMiddlewareTest extends TestCase
 
     public function testAllowsOnlyOneWorkflowInstance(): void
     {
-        $workflow1 = $this->mock(TestWorkflow::class);
+        $workflow1 = Mockery::mock(TestWorkflow::class);
         $middleware1 = new WithoutOverlappingMiddleware(1, WithoutOverlappingMiddleware::WORKFLOW);
 
-        $workflow2 = $this->mock(TestWorkflow::class, static function (MockInterface $mock) {
+        $workflow2 = Mockery::mock(TestWorkflow::class, static function (MockInterface $mock) {
             $mock->shouldReceive('release')
                 ->once();
         });
         $middleware2 = new WithoutOverlappingMiddleware(1, WithoutOverlappingMiddleware::WORKFLOW);
 
-        $activity = $this->mock(TestActivity::class, static function (MockInterface $mock) {
+        $activity = Mockery::mock(TestActivity::class, static function (MockInterface $mock) {
             $mock->shouldReceive('release')
                 ->once();
         });
@@ -65,13 +66,13 @@ final class WithoutOverlappingMiddlewareTest extends TestCase
 
     public function testAllowsMultipleActivityInstances(): void
     {
-        $activity1 = $this->mock(TestActivity::class);
+        $activity1 = Mockery::mock(TestActivity::class);
         $middleware1 = new WithoutOverlappingMiddleware(1, WithoutOverlappingMiddleware::ACTIVITY);
 
-        $activity2 = $this->mock(TestActivity::class);
+        $activity2 = Mockery::mock(TestActivity::class);
         $middleware2 = new WithoutOverlappingMiddleware(1, WithoutOverlappingMiddleware::ACTIVITY);
 
-        $workflow1 = $this->mock(TestWorkflow::class, static function (MockInterface $mock) {
+        $workflow1 = Mockery::mock(TestWorkflow::class, static function (MockInterface $mock) {
             $mock->shouldReceive('release')
                 ->once();
         });

--- a/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
+++ b/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
@@ -51,7 +51,7 @@ final class WithoutOverlappingMiddlewareTest extends TestCase
             $activity,
             $middleware3
         ) {
-            $this->assertSame('1', Cache::get($middleware1->getWorkflowSemaphoreKey()));
+            $this->assertSame(1, Cache::get($middleware1->getWorkflowSemaphoreKey()));
             $this->assertNull(Cache::get($middleware1->getActivitySemaphoreKey()));
 
             $middleware2->handle($workflow2, static function ($job) {

--- a/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
+++ b/tests/Unit/Middleware/WithoutOverlappingMiddlewareTest.php
@@ -50,7 +50,7 @@ final class WithoutOverlappingMiddlewareTest extends TestCase
             $activity,
             $middleware3
         ) {
-            $this->assertSame(1, Cache::get($middleware1->getWorkflowSemaphoreKey()));
+            $this->assertSame('1', Cache::get($middleware1->getWorkflowSemaphoreKey()));
             $this->assertNull(Cache::get($middleware1->getActivitySemaphoreKey()));
 
             $middleware2->handle($workflow2, static function ($job) {

--- a/tests/Unit/Middleware/WorkflowMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowMiddlewareTest.php
@@ -12,6 +12,7 @@ use Mockery\MockInterface;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\Events\ActivityCompleted;
 use Workflow\Events\ActivityFailed;
 use Workflow\Events\ActivityStarted;
@@ -22,7 +23,7 @@ use Workflow\States\WorkflowRunningStatus;
 use Workflow\States\WorkflowWaitingStatus;
 use Workflow\WorkflowStub;
 
-final class WorkflowMiddlewareTest extends TestCase
+final class WorkflowMiddlewareTest extends TestCaseRequiringDatabase
 {
     public function testMiddleware(): void
     {

--- a/tests/Unit/Middleware/WorkflowMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowMiddlewareTest.php
@@ -11,7 +11,6 @@ use Mockery;
 use Mockery\MockInterface;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\Events\ActivityCompleted;
 use Workflow\Events\ActivityFailed;

--- a/tests/Unit/Middleware/WorkflowMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Middleware;
 use Exception;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
+use Mockery;
 use Mockery\MockInterface;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestWorkflow;
@@ -20,6 +21,7 @@ use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowRunningStatus;
 use Workflow\States\WorkflowWaitingStatus;
 use Workflow\WorkflowStub;
+use function PHPStan\dumpType;
 
 final class WorkflowMiddlewareTest extends TestCase
 {
@@ -36,7 +38,7 @@ final class WorkflowMiddlewareTest extends TestCase
             'status' => WorkflowWaitingStatus::class,
         ]);
 
-        $activity = $this->mock(TestActivity::class);
+        $activity = Mockery::mock(TestActivity::class);
         $activity->index = 0;
         $activity->now = now()
             ->toDateTimeString();
@@ -66,7 +68,7 @@ final class WorkflowMiddlewareTest extends TestCase
             'status' => WorkflowCompletedStatus::class,
         ]);
 
-        $activity = $this->mock(TestActivity::class);
+        $activity = Mockery::mock(TestActivity::class);
         $activity->index = 0;
         $activity->now = now()
             ->toDateTimeString();
@@ -97,7 +99,7 @@ final class WorkflowMiddlewareTest extends TestCase
             'status' => WorkflowRunningStatus::class,
         ]);
 
-        $activity = $this->mock(TestActivity::class, static function (MockInterface $mock) {
+        $activity = Mockery::mock(TestActivity::class, static function (MockInterface $mock) {
             $mock->shouldReceive('release')
                 ->once();
         });
@@ -131,7 +133,7 @@ final class WorkflowMiddlewareTest extends TestCase
             'status' => WorkflowWaitingStatus::class,
         ]);
 
-        $activity = $this->mock(TestActivity::class);
+        $activity = Mockery::mock(TestActivity::class);
         $activity->index = 0;
         $activity->now = now()
             ->toDateTimeString();

--- a/tests/Unit/Middleware/WorkflowMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowMiddlewareTest.php
@@ -21,7 +21,6 @@ use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowRunningStatus;
 use Workflow\States\WorkflowWaitingStatus;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 final class WorkflowMiddlewareTest extends TestCase
 {

--- a/tests/Unit/Models/StoredWorkflowTest.php
+++ b/tests/Unit/Models/StoredWorkflowTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit\Models;
 
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 
-final class StoredWorkflowTest extends TestCase
+final class StoredWorkflowTest extends TestCaseRequiringDatabase
 {
     public function testModel(): void
     {

--- a/tests/Unit/Models/StoredWorkflowTest.php
+++ b/tests/Unit/Models/StoredWorkflowTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Models;
 
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 

--- a/tests/Unit/Serializers/EncodeTest.php
+++ b/tests/Unit/Serializers/EncodeTest.php
@@ -20,7 +20,6 @@ final class EncodeTest extends TestCase
 
     /**
      * @return array<string, string[]>
-     * @throws \Random\RandomException
      */
     public function dataProvider(): array
     {

--- a/tests/Unit/Serializers/EncodeTest.php
+++ b/tests/Unit/Serializers/EncodeTest.php
@@ -18,6 +18,10 @@ final class EncodeTest extends TestCase
         $this->assertSame($bytes, $decoded);
     }
 
+    /**
+     * @return array<string, string[]>
+     * @throws \Random\RandomException
+     */
     public function dataProvider(): array
     {
         return [

--- a/tests/Unit/Serializers/SerializeTest.php
+++ b/tests/Unit/Serializers/SerializeTest.php
@@ -39,7 +39,7 @@ final class SerializeTest extends TestCase
     }
 
     /**
-     * @return array<string, list<mixed>>
+     * @return array<string, array<int|string, mixed>>
      * @throws \Random\RandomException
      */
     public function dataProvider(): array

--- a/tests/Unit/Serializers/SerializeTest.php
+++ b/tests/Unit/Serializers/SerializeTest.php
@@ -12,6 +12,7 @@ use Workflow\Serializers\Y;
 final class SerializeTest extends TestCase
 {
     /**
+     * @param mixed $data
      * @dataProvider dataProvider
      */
     public function testSerialize($data): void
@@ -37,6 +38,10 @@ final class SerializeTest extends TestCase
         }
     }
 
+    /**
+     * @return array<string, list<mixed>>
+     * @throws \Random\RandomException
+     */
     public function dataProvider(): array
     {
         return [

--- a/tests/Unit/Serializers/SerializeTest.php
+++ b/tests/Unit/Serializers/SerializeTest.php
@@ -40,7 +40,6 @@ final class SerializeTest extends TestCase
 
     /**
      * @return array<string, array<int|string, mixed>>
-     * @throws \Random\RandomException
      */
     public function dataProvider(): array
     {

--- a/tests/Unit/States/WorkflowStatusTest.php
+++ b/tests/Unit/States/WorkflowStatusTest.php
@@ -17,7 +17,9 @@ final class WorkflowStatusTest extends TestCase
 {
     public function testConfig(): void
     {
-        $config = (new StoredWorkflow())->getStates()->first()->all();
+        $config = (new StoredWorkflow())->getStates()
+            ->first()
+            ->all();
         $this->assertSame([
             WorkflowCompletedStatus::$name,
             WorkflowCreatedStatus::$name,

--- a/tests/Unit/States/WorkflowStatusTest.php
+++ b/tests/Unit/States/WorkflowStatusTest.php
@@ -17,7 +17,7 @@ final class WorkflowStatusTest extends TestCase
 {
     public function testConfig(): void
     {
-        $config = StoredWorkflow::make()->getStates()->first()->all();
+        $config = (new StoredWorkflow())->getStates()->first()->all();
         $this->assertSame([
             WorkflowCompletedStatus::$name,
             WorkflowCreatedStatus::$name,

--- a/tests/Unit/Traits/AwaitWithTimeoutsTest.php
+++ b/tests/Unit/Traits/AwaitWithTimeoutsTest.php
@@ -57,7 +57,8 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertTrue(Y::unserialize($firstLog->result));
@@ -87,7 +88,8 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertTrue(Y::unserialize($firstLog->result));
@@ -119,7 +121,8 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertFalse(Y::unserialize($firstLog->result));

--- a/tests/Unit/Traits/AwaitWithTimeoutsTest.php
+++ b/tests/Unit/Traits/AwaitWithTimeoutsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\States\WorkflowPendingStatus;
@@ -56,7 +57,10 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertTrue(Y::unserialize($firstLog->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -83,7 +87,10 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertTrue(Y::unserialize($firstLog->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -112,6 +119,9 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertFalse(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertFalse(Y::unserialize($firstLog->result));
     }
 }

--- a/tests/Unit/Traits/AwaitsTest.php
+++ b/tests/Unit/Traits/AwaitsTest.php
@@ -43,7 +43,8 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertTrue(Y::unserialize($firstLog->result));
@@ -73,7 +74,8 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertTrue(Y::unserialize($firstLog->result));
@@ -105,7 +107,8 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertFalse(Y::unserialize($firstLog->result));

--- a/tests/Unit/Traits/AwaitsTest.php
+++ b/tests/Unit/Traits/AwaitsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\WorkflowStub;
@@ -42,7 +43,10 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertTrue(Y::unserialize($firstLog->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -69,7 +73,10 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertTrue(Y::unserialize($firstLog->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -98,6 +105,9 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertFalse(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertFalse(Y::unserialize($firstLog->result));
     }
 }

--- a/tests/Unit/Traits/SagasTest.php
+++ b/tests/Unit/Traits/SagasTest.php
@@ -9,7 +9,6 @@ use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 final class SagasTest extends TestCase
 {

--- a/tests/Unit/Traits/SagasTest.php
+++ b/tests/Unit/Traits/SagasTest.php
@@ -9,11 +9,13 @@ use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\WorkflowStub;
+use function PHPStan\dumpType;
 
 final class SagasTest extends TestCase
 {
     public function testCompensation(): void
     {
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $job = new ($storedWorkflow->class)($storedWorkflow, []);
@@ -24,6 +26,7 @@ final class SagasTest extends TestCase
     public function testCompensationWithError(): void
     {
         $this->expectException(Exception::class);
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $job = new ($storedWorkflow->class)($storedWorkflow, []);
@@ -33,6 +36,7 @@ final class SagasTest extends TestCase
 
     public function testCompensationContinueWithError(): void
     {
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $job = new ($storedWorkflow->class)($storedWorkflow, []);

--- a/tests/Unit/Traits/SideEffectsTest.php
+++ b/tests/Unit/Traits/SideEffectsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\WorkflowStub;
 
@@ -28,7 +29,10 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertSame('test', Y::unserialize($firstLog->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -55,7 +59,10 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertSame('test', Y::unserialize($firstLog->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -84,6 +91,9 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertSame('test', Y::unserialize($firstLog->result));
     }
 }

--- a/tests/Unit/Traits/SideEffectsTest.php
+++ b/tests/Unit/Traits/SideEffectsTest.php
@@ -29,7 +29,8 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertSame('test', Y::unserialize($firstLog->result));
@@ -59,7 +60,8 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertSame('test', Y::unserialize($firstLog->result));
@@ -91,7 +93,8 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertSame('test', Y::unserialize($firstLog->result));

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -105,7 +105,8 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertSame(true, Y::unserialize($firstLog->result));
@@ -140,7 +141,8 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $firstLog = $workflow->logs()
+            ->firstWhere('index', 0);
         $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
         $this->assertNotNull($firstLog->result);
         $this->assertSame(true, Y::unserialize($firstLog->result));

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -73,7 +73,7 @@ final class TimersTest extends TestCase
         $this->assertNull($result);
         $this->assertSame(0, $workflow->logs()->count());
 
-        WorkflowStub::timer('1 minute', static fn () => false)
+        WorkflowStub::timer('1 minute')
             ->then(static function ($value) use (&$result) {
                 $result = $value;
             });
@@ -124,7 +124,7 @@ final class TimersTest extends TestCase
                 'result' => Y::serialize(true),
             ]);
 
-        WorkflowStub::timer('1 minute', static fn () => true)
+        WorkflowStub::timer('1 minute')
             ->then(static function ($value) use (&$result) {
                 $result = $value;
             });

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\States\WorkflowPendingStatus;
@@ -104,7 +105,10 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertSame(true, Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertSame(true, Y::unserialize($firstLog->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -136,6 +140,9 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertSame(true, Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $firstLog = $workflow->logs()->firstWhere('index', 0);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $firstLog);
+        $this->assertNotNull($firstLog->result);
+        $this->assertSame(true, Y::unserialize($firstLog->result));
     }
 }

--- a/tests/Unit/WorkflowFakerTest.php
+++ b/tests/Unit/WorkflowFakerTest.php
@@ -11,9 +11,10 @@ use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\Fixtures\TestTimeTravelWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\WorkflowStub;
 
-final class WorkflowFakerTest extends TestCase
+final class WorkflowFakerTest extends TestCaseRequiringDatabase
 {
     public function testTimeTravelWorkflow(): void
     {

--- a/tests/Unit/WorkflowFakerTest.php
+++ b/tests/Unit/WorkflowFakerTest.php
@@ -10,7 +10,6 @@ use Tests\Fixtures\TestConcurrentWorkflow;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\Fixtures\TestTimeTravelWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\WorkflowStub;
 

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -11,6 +11,7 @@ use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
@@ -92,7 +93,7 @@ final class WorkflowStubTest extends TestCase
 
         $workflow = WorkflowStub::load($workflow->id());
 
-        $this->assertSame(0, WorkflowStub::getContext()->index);
+        $this->assertSame(0, WorkflowStub::getContext()?->index);
 
         $promise = WorkflowStub::await(static fn () => false);
 
@@ -109,7 +110,10 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $log = $workflow->logs()->firstWhere('index', 1);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $log);
+        $this->assertNotNull($log->result);
+        $this->assertTrue(Y::unserialize($log->result));
 
         $workflow->fresh();
         $context = WorkflowStub::getContext();
@@ -132,7 +136,7 @@ final class WorkflowStubTest extends TestCase
 
         $workflow = WorkflowStub::load($workflow->id());
 
-        $this->assertSame(0, WorkflowStub::getContext()->index);
+        $this->assertSame(0, WorkflowStub::getContext()?->index);
 
         $promise = WorkflowStub::awaitWithTimeout(60, static fn () => false);
 
@@ -149,7 +153,10 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $log = $workflow->logs()->firstWhere('index', 1);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $log);
+        $this->assertNotNull($log->result);
+        $this->assertTrue(Y::unserialize($log->result));
 
         $workflow->fresh();
         $context = WorkflowStub::getContext();
@@ -171,7 +178,7 @@ final class WorkflowStubTest extends TestCase
         while (! $workflow->isCanceled());
 
         $this->assertSame(1, $workflow->logs()->count());
-        $this->assertSame(1, WorkflowStub::getContext()->index);
+        $this->assertSame(1, WorkflowStub::getContext()?->index);
 
         $workflow = WorkflowStub::load($workflow->id());
         $context = WorkflowStub::getContext();
@@ -198,7 +205,10 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $log = $workflow->logs()->firstWhere('index', 1);
+        $this->assertInstanceOf(StoredWorkflowLog::class, $log);
+        $this->assertNotNull($log->result);
+        $this->assertTrue(Y::unserialize($log->result));
     }
 
     public function testConnection(): void

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -16,9 +16,7 @@ use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
-use Workflow\Workflow;
 use Workflow\WorkflowStub;
-use function PHPStan\dumpType;
 
 final class WorkflowStubTest extends TestCase
 {
@@ -110,7 +108,8 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $log = $workflow->logs()->firstWhere('index', 1);
+        $log = $workflow->logs()
+            ->firstWhere('index', 1);
         $this->assertInstanceOf(StoredWorkflowLog::class, $log);
         $this->assertNotNull($log->result);
         $this->assertTrue(Y::unserialize($log->result));
@@ -153,7 +152,8 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $log = $workflow->logs()->firstWhere('index', 1);
+        $log = $workflow->logs()
+            ->firstWhere('index', 1);
         $this->assertInstanceOf(StoredWorkflowLog::class, $log);
         $this->assertNotNull($log->result);
         $this->assertTrue(Y::unserialize($log->result));
@@ -205,7 +205,8 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $log = $workflow->logs()->firstWhere('index', 1);
+        $log = $workflow->logs()
+            ->firstWhere('index', 1);
         $this->assertInstanceOf(StoredWorkflowLog::class, $log);
         $this->assertNotNull($log->result);
         $this->assertTrue(Y::unserialize($log->result));

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -15,7 +15,9 @@ use Workflow\Serializers\Y;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
+use Workflow\Workflow;
 use Workflow\WorkflowStub;
+use function PHPStan\dumpType;
 
 final class WorkflowStubTest extends TestCase
 {

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -32,6 +32,7 @@ final class WorkflowStubTest extends TestCase
             'status' => WorkflowPendingStatus::$name,
         ]);
 
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $workflow->start();
@@ -83,6 +84,7 @@ final class WorkflowStubTest extends TestCase
 
     public function testAwait(): void
     {
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $workflow->start();
         $workflow->cancel();
@@ -122,6 +124,7 @@ final class WorkflowStubTest extends TestCase
 
     public function testAwaitWithTimeout(): void
     {
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $workflow->start();
         $workflow->cancel();
@@ -161,6 +164,7 @@ final class WorkflowStubTest extends TestCase
 
     public function testAwaitWithTimeoutTimedout(): void
     {
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $workflow->start();
         $workflow->cancel();
@@ -201,6 +205,7 @@ final class WorkflowStubTest extends TestCase
     {
         Carbon::setTestNow('2022-01-01');
 
+        /** @var WorkflowStub<TestWorkflow> $workflow */
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $otherWorkflow = WorkflowStub::load(WorkflowStub::make(TestBadConnectionWorkflow::class)->id());
 

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Carbon;
 use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Models\StoredWorkflowLog;

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -10,6 +10,7 @@ use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Y;
@@ -18,7 +19,7 @@ use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
-final class WorkflowStubTest extends TestCase
+final class WorkflowStubTest extends TestCaseRequiringDatabase
 {
     public function testMake(): void
     {

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -10,7 +10,6 @@ use Tests\Fixtures\TestChildWorkflow;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\Fixtures\TestWorkflow;
-use Tests\TestCase;
 use Tests\TestCaseRequiringDatabase;
 use Workflow\Exception;
 use Workflow\Exceptions\Transformer;

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -11,6 +11,7 @@ use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Tests\TestCaseRequiringDatabase;
 use Workflow\Exception;
 use Workflow\Exceptions\Transformer;
 use Workflow\Models\StoredWorkflow;
@@ -19,7 +20,7 @@ use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
-final class WorkflowTest extends TestCase
+final class WorkflowTest extends TestCaseRequiringDatabase
 {
     public function testException(): void
     {

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -12,6 +12,7 @@ use Tests\Fixtures\TestParentWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
+use Workflow\Exceptions\Transformer;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Y;
 use Workflow\States\WorkflowCompletedStatus;
@@ -22,7 +23,9 @@ final class WorkflowTest extends TestCase
 {
     public function testException(): void
     {
-        $exception = new \Exception('test');
+        $exception = app(Transformer::class)
+            ->withoutArgs()
+            ->transform(new \Exception('test'));
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $activity = new Exception(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(
             $workflow->id()
@@ -35,7 +38,9 @@ final class WorkflowTest extends TestCase
 
     public function testExceptionAlreadyLogged(): void
     {
-        $exception = new \Exception('test');
+        $exception = app(Transformer::class)
+            ->withoutArgs()
+            ->transform(new \Exception('test'));
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $activity = new Exception(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(


### PR DESCRIPTION
This PR makes PHPStan happy up to level 8. 

- To (temporarily) keep compatibility with PHP 8.0 and with 1.x of this package, some type hints are currently only in docblocks. 
- The unit tests are now run in the CI pipeline, too
- The tests run faster by only initializing the database/queue workers if needed
- `Workflow\Exceptions\Transformer` was introduced to always pass the correct object to methods and to prevent `Data too long` errors when trying to add serialized exceptions to the database
- For the same reason, `workflow_exceptions.exceptions` is now a `LONGTEXT` column

There is only one test failing, and I cannot see how this test could ever have been successful - although it obviously was run by the CI pipeline.

The test in question is `\Tests\Feature\WorkflowTest::testCompletedDelay`. 

If I see it correctly, the test is guaranteed to hit the `assert`-Call in `tests/Fixtures/TestWorkflow.php:46` after having received the `cancel`-Signal. I assume the CI pipeline uses/used a container where `zend.assertions=0` was set.

IMO everything related to `shouldAssert` in `TestWorkflow` can be removed. Please let me know if this assumption is correct.