### PR TITLE
Static functions to ease creation of activities and workflows

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -63,11 +63,10 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-    public static function make(...$args) : PromiseInterface
+    public static function make(...$args): PromiseInterface
     {
         return ActivityStub::make(static::class, ...$args);
     }
-
 
     public function backoff()
     {

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -16,6 +16,7 @@ use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use LimitIterator;
+use React\Promise\PromiseInterface;
 use SplFileObject;
 use Throwable;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
@@ -62,7 +63,13 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-    public function backoff()
+	public static function make(...$args) : PromiseInterface
+	{
+		return ActivityStub::make(static::class, ...$args);
+	}
+
+
+	public function backoff()
     {
         return [1, 2, 5, 10, 15, 30, 60, 120];
     }

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -63,13 +63,13 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-	public static function make(...$args) : PromiseInterface
-	{
-		return ActivityStub::make(static::class, ...$args);
-	}
+    public static function make(...$args) : PromiseInterface
+    {
+        return ActivityStub::make(static::class, ...$args);
+    }
 
 
-	public function backoff()
+    public function backoff()
     {
         return [1, 2, 5, 10, 15, 30, 60, 120];
     }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -69,7 +69,17 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-    public function query($method)
+	public static function make() : WorkflowStub
+	{
+		return WorkflowStub::make(static::class);
+	}
+
+	public static function makeChild(...$args) : PromiseInterface
+	{
+		return ChildWorkflowStub::make(static::class, ...$args);
+	}
+
+	public function query($method)
     {
         $this->replaying = true;
         $this->handle();

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -69,17 +69,17 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-    public static function make() : WorkflowStub
+    public static function make(): WorkflowStub
     {
         return WorkflowStub::make(static::class);
     }
 
-    public static function makeChild(...$args) : PromiseInterface
+    public static function makeChild(...$args): PromiseInterface
     {
         return ChildWorkflowStub::make(static::class, ...$args);
     }
 
-    public static function start(...$args) : WorkflowStub
+    public static function start(...$args): WorkflowStub
 	{
 		$workflow = self::make();
 		$workflow->start(...$args);

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -78,6 +78,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
     {
         return ChildWorkflowStub::make(static::class, ...$args);
     }
+
     public static function start(...$args): WorkflowStub
     {
         $workflow = self::make();

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -79,6 +79,13 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
 		return ChildWorkflowStub::make(static::class, ...$args);
 	}
 
+	public static function start(...$args) : WorkflowStub
+	{
+		$workflow = self::make();
+		$workflow->start(...$args);
+		return $workflow;
+	}
+
 	public function query($method)
     {
         $this->replaying = true;

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -69,17 +69,17 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
         $this->afterCommit = true;
     }
 
-	public static function make() : WorkflowStub
-	{
-		return WorkflowStub::make(static::class);
-	}
+    public static function make() : WorkflowStub
+    {
+        return WorkflowStub::make(static::class);
+    }
 
-	public static function makeChild(...$args) : PromiseInterface
-	{
-		return ChildWorkflowStub::make(static::class, ...$args);
-	}
+    public static function makeChild(...$args) : PromiseInterface
+    {
+        return ChildWorkflowStub::make(static::class, ...$args);
+    }
 
-	public static function start(...$args) : WorkflowStub
+    public static function start(...$args) : WorkflowStub
 	{
 		$workflow = self::make();
 		$workflow->start(...$args);

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -78,15 +78,14 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
     {
         return ChildWorkflowStub::make(static::class, ...$args);
     }
-
     public static function start(...$args): WorkflowStub
-	{
-		$workflow = self::make();
-		$workflow->start(...$args);
-		return $workflow;
-	}
+    {
+        $workflow = self::make();
+        $workflow->start(...$args);
+        return $workflow;
+    }
 
-	public function query($method)
+    public function query($method)
     {
         $this->replaying = true;
         $this->handle();


### PR DESCRIPTION
Currently, creating workflows and activities require verbose syntax.

For example:

```php
// Create and start a workflow
$workflow = \Workflow\WorkflowStub::make(MyWorkflow::class);
$workflow->start(argA, $argB, $argC, $argN);

// Create and yield a child workflow from a workflow
yield \Workflow\ChildWorkflowStub::make(MyWorkflow::class, $argA, $argB, $argC, $argN);

// Create and yield an activity from a workflow
yield \Workflow\ActivityStub::make(MyActivity::class, $argA, $argB, $argC, $argN);
```

This PR adds 3 new static functions, 2 for workflows and 1 for activities. These new static functions allow the above example to be re-written like this:

```php
// Create and start a workflow
$workflow = MyWorkflow::make();
$workflow->start(argA, $argB, $argC, $argN);

// Create and yield a child workflow from a workflow
yield MyWorkflow::makeChild($argA, $argB, $argC, $argN);

// Create and yield an activity from a workflow
yield MyActivity::make($argA, $argB, $argC, $argN);
```

I also considered one more static function `\Workflow\Workflow::start(...$args)`:

```php
public static function start(...$args) : WorkflowStub
{
	$workflow = self::make();
	$workflow->start(...$args);
	return $workflow;
}
```

This would allow starting a workflow like this:

```php
// Create and start a workflow
$workflow = MyWorkflow::start(argA, $argB, $argC, $argN);
```

I'm using this and it seems to work well, and I can't see any reason this is a poor design decision, but I am open to thoughts. Is this is better (cleaner) way to write these declarations?