### PR TITLE
Fix Transition from `pending` to `pending` on model `App\Workflows\St…

### DIFF
--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -226,12 +226,11 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             );
 
             if ($parentWorkflow) {
-
                 try {
                     $parentWorkflow->toWorkflow()
                         ->next($parentWorkflow->pivot->parent_index, $this->now, $this->storedWorkflow->class, $return);
                 } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
-                    //Do nothing
+                    return;
                 }
             }
         }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -226,8 +226,13 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             );
 
             if ($parentWorkflow) {
-                $parentWorkflow->toWorkflow()
-                    ->next($parentWorkflow->pivot->parent_index, $this->now, $this->storedWorkflow->class, $return);
+
+                try {
+                    $parentWorkflow->toWorkflow()
+                        ->next($parentWorkflow->pivot->parent_index, $this->now, $this->storedWorkflow->class, $return);
+                } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
+                    //Do nothing
+                }
             }
         }
     }

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -286,11 +286,7 @@ final class WorkflowStub
             );
         }
 
-        try {
-            $this->storedWorkflow->status->transitionTo(WorkflowPendingStatus::class);
-        } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
-            return;
-        }
+        $this->storedWorkflow->status->transitionTo(WorkflowPendingStatus::class);
 
         $dispatch = static::faked() ? 'dispatchSync' : 'dispatch';
 

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -286,7 +286,11 @@ final class WorkflowStub
             );
         }
 
-        $this->storedWorkflow->status->transitionTo(WorkflowPendingStatus::class);
+        try {
+            $this->storedWorkflow->status->transitionTo(WorkflowPendingStatus::class);
+        } catch (\Spatie\ModelStates\Exceptions\TransitionNotFound) {
+            return;
+        }
 
         $dispatch = static::faked() ? 'dispatchSync' : 'dispatch';
 


### PR DESCRIPTION
…oredWorkflow` was not found when using Nested Parallel child workflows