### PR TITLE
Implemented tags for Workflows

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -32,6 +32,7 @@ class StoredWorkflow extends Model
      */
     protected $casts = [
         'status' => WorkflowStatus::class,
+        'tags'   => 'array'
     ];
 
     public function toWorkflow()

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -32,7 +32,7 @@ class StoredWorkflow extends Model
      */
     protected $casts = [
         'status' => WorkflowStatus::class,
-        'tags'   => 'array'
+        'tags' => 'array',
     ];
 
     public function toWorkflow()

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -144,6 +144,11 @@ final class WorkflowStub
         return $this->storedWorkflow->logs;
     }
 
+    public function tags()
+    {
+        return $this->storedWorkflow->tags;
+    }
+
     public function exceptions()
     {
         return $this->storedWorkflow->exceptions;
@@ -176,6 +181,12 @@ final class WorkflowStub
     public function running(): bool
     {
         return ! in_array($this->status(), [WorkflowCompletedStatus::class, WorkflowFailedStatus::class], true);
+    }
+
+    public function setTags(...$tags) : static
+    {
+        $this->storedWorkflow->tags = is_array($tags[0]) ? $tags[0] : $tags;
+        return $this;
     }
 
     public function status(): string|bool

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -183,7 +183,7 @@ final class WorkflowStub
         return ! in_array($this->status(), [WorkflowCompletedStatus::class, WorkflowFailedStatus::class], true);
     }
 
-    public function setTags(...$tags) : static
+    public function setTags(...$tags): static
     {
         $this->storedWorkflow->tags = is_array($tags[0]) ? $tags[0] : $tags;
         return $this;

--- a/src/migrations/2022_01_01_000000_create_workflows_table.php
+++ b/src/migrations/2022_01_01_000000_create_workflows_table.php
@@ -20,8 +20,6 @@ final class CreateWorkflowsTable extends Migration
                 ->nullable();
             $blueprint->text('output')
                 ->nullable();
-            $blueprint->json('tags')
-                ->nullable();
             $blueprint->string('status')
                 ->default('pending')
                 ->index();

--- a/src/migrations/2022_01_01_000000_create_workflows_table.php
+++ b/src/migrations/2022_01_01_000000_create_workflows_table.php
@@ -20,6 +20,8 @@ final class CreateWorkflowsTable extends Migration
                 ->nullable();
             $blueprint->text('output')
                 ->nullable();
+            $blueprint->json('tags')
+                ->nullable();
             $blueprint->string('status')
                 ->default('pending')
                 ->index();

--- a/src/migrations/2022_01_01_000006_add_tags_workflows_table.php
+++ b/src/migrations/2022_01_01_000006_add_tags_workflows_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class AddTagsWorkflowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('workflows', static function (Blueprint $blueprint) {
+            $blueprint->json('tags')
+                ->nullable()
+                ->after('output');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('workflows', static function (Blueprint $blueprint) {
+            $blueprint->dropColumn('tags');
+        });
+    }
+}

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use Exception;
 use Illuminate\Support\Carbon;
+use PHPUnit\Util\Test;
 use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
@@ -207,4 +208,23 @@ final class WorkflowStubTest extends TestCase
         $this->assertSame('redis', WorkflowStub::connection());
         $this->assertSame('default', WorkflowStub::queue());
     }
+
+
+    public function testTags()
+    {
+        $tags = ['one', 'two'];
+
+        $workflow = WorkflowStub::make(TestWorkflow::class)
+            ->setTags('one', 'two');
+
+        $workflow->cancel();
+        $this->assertSame($tags, $workflow->tags());
+
+        $workflow = WorkflowStub::make(TestWorkflow::class)
+            ->setTags($tags);
+
+        $workflow->cancel();
+        $this->assertSame($tags, $workflow->tags());
+    }
+
 }

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit;
 
 use Exception;
 use Illuminate\Support\Carbon;
-use PHPUnit\Util\Test;
 use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
@@ -209,7 +208,6 @@ final class WorkflowStubTest extends TestCase
         $this->assertSame('default', WorkflowStub::queue());
     }
 
-
     public function testTags()
     {
         $tags = ['one', 'two'];
@@ -226,5 +224,4 @@ final class WorkflowStubTest extends TestCase
         $workflow->cancel();
         $this->assertSame($tags, $workflow->tags());
     }
-
 }


### PR DESCRIPTION
Tags will allow to identify and to label the Workflows. This feature was inspired in the [Laravel Horizon tags](https://laravel.com/docs/11.x/horizon#tags).

The WorkflowStub will allow to set the tags through the setTags methods.

Ex:

  WorkflowStub::make(TestWorkflow::class)
              ->setTags('one', 'two');

or

   WorkflowStub::make(TestWorkflow::class)
            ->setTags(['one', 'two']);

The workflow tags can be retrieved calling the tags method.

Ex:

    WorkflowStub::make(TestWorkflow::class)
              ->setTags('one', 'two')
    ->tags();


 