### PR TITLE
Set default order for workflow relations

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -44,22 +44,26 @@ class StoredWorkflow extends Model
 
     public function logs(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class))->orderBy('id');
+        return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class))
+            ->orderBy('id');
     }
 
     public function signals(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class))->orderBy('id');
+        return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class))
+            ->orderBy('id');
     }
 
     public function timers(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class))->orderBy('id');
+        return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class))
+            ->orderBy('id');
     }
 
     public function exceptions(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class))->orderBy('id');
+        return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class))
+            ->orderBy('id');
     }
 
     public function parents(): \Illuminate\Database\Eloquent\Relations\BelongsToMany

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -44,22 +44,22 @@ class StoredWorkflow extends Model
 
     public function logs(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class));
+        return $this->hasMany(config('workflows.stored_workflow_log_model', StoredWorkflowLog::class))->orderBy('id');
     }
 
     public function signals(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class));
+        return $this->hasMany(config('workflows.stored_workflow_signal_model', StoredWorkflowSignal::class))->orderBy('id');
     }
 
     public function timers(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class));
+        return $this->hasMany(config('workflows.stored_workflow_timer_model', StoredWorkflowTimer::class))->orderBy('id');
     }
 
     public function exceptions(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class));
+        return $this->hasMany(config('workflows.stored_workflow_exception_model', StoredWorkflowException::class))->orderBy('id');
     }
 
     public function parents(): \Illuminate\Database\Eloquent\Relations\BelongsToMany


### PR DESCRIPTION
The relations 'logs', 'signals', 'timers' and 'exceptions' were sometimes returned out-of-order

Waterline displays these relations without reordering them as well, which in turn would show incorrect information about their order of execution and their time

![image](https://github.com/user-attachments/assets/848183c6-26dd-4f39-a95c-7f449a65c042)
