### PR TITLE
Added NonRetryableException

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 namespace Workflow;
 
-use Throwable;
-use LimitIterator;
-use SplFileObject;
 use BadMethodCallException;
-use Workflow\Serializers\Y;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
-use Illuminate\Support\Facades\App;
-use Workflow\Models\StoredWorkflow;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Workflow\Middleware\ActivityMiddleware;
-use Workflow\Exceptions\NonRetryableException;
-use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Routing\RouteDependencyResolverTrait;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
+use LimitIterator;
+use SplFileObject;
+use Throwable;
+use Workflow\Exceptions\NonRetryableException;
+use Workflow\Middleware\ActivityMiddleware;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Y;
 
 class Activity implements ShouldBeEncrypted, ShouldQueue
 {
@@ -129,7 +129,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
             'line' => $throwable->getLine(),
             'file' => $throwable->getFile(),
             'trace' => collect($throwable->getTrace())
-                ->filter(static fn($trace) => Y::serializable($trace))
+                ->filter(static fn ($trace) => Y::serializable($trace))
                 ->toArray(),
             'snippet' => array_slice(iterator_to_array($iterator), 0, 7),
         ];

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\Cache;
 use LimitIterator;
 use SplFileObject;
 use Throwable;
-use Workflow\Exceptions\NonRetryableException;
+use Workflow\Exceptions\NonRetryableExceptionContract;
 use Workflow\Middleware\ActivityMiddleware;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
@@ -94,7 +94,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
                     'exception' => Y::serialize($throwable),
                 ]);
 
-            if ($throwable instanceof NonRetryableException) {
+            if ($throwable instanceof NonRetryableExceptionContract) {
                 $this->fail($throwable);
             }
 

--- a/src/Exceptions/NonRetryableException.php
+++ b/src/Exceptions/NonRetryableException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class NonRetryableException extends Exception
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = '', $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/NonRetryableException.php
+++ b/src/Exceptions/NonRetryableException.php
@@ -7,7 +7,7 @@ namespace Workflow\Exceptions;
 use Exception;
 use Throwable;
 
-class NonRetryableException extends Exception
+class NonRetryableException extends Exception implements NonRetryableExceptionContract
 {
     public function __construct($message = '', $code = 0, Throwable $previous = null)
     {

--- a/src/Exceptions/NonRetryableException.php
+++ b/src/Exceptions/NonRetryableException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Exceptions;
+
+use Exception;
+use Throwable;
+
+class NonRetryableException extends Exception
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Exceptions/NonRetryableExceptionContract.php
+++ b/src/Exceptions/NonRetryableExceptionContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Exceptions;
+
+interface NonRetryableExceptionContract
+{
+}

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\TestCase;
-use Workflow\Serializers\Y;
-use Workflow\States\WorkflowCompletedStatus;
 use Workflow\WorkflowStub;
+use Workflow\Serializers\Y;
+use Tests\Fixtures\TestExceptionWorkflow;
+use Workflow\States\WorkflowFailedStatus;
+use Workflow\States\WorkflowCompletedStatus;
+use Tests\Fixtures\NonRetryableTestExceptionActivity;
 
 final class ExceptionWorkflowTest extends TestCase
 {
@@ -25,5 +27,21 @@ final class ExceptionWorkflowTest extends TestCase
         if ($workflow->exceptions()->first()) {
             $this->assertSame('failed', Y::unserialize($workflow->exceptions()->first()->exception)['message']);
         }
+    }
+
+    public function testNonRetryableException(): void
+    {
+        $workflow = WorkflowStub::make(NonRetryableTestExceptionActivity::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
+        $this->assertNotNull($workflow->exceptions()->first());
+        $this->assertNull($workflow->output());
+        $this->assertSame('This is a non-retryable error', Y::unserialize($workflow->exceptions()->first()->exception)['message']);
+
+        $this->assertCount(1, $workflow->exceptions());
     }
 }

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Tests\Fixtures\NonRetryableTestExceptionActivity;
+use Tests\Fixtures\NonRetryableTestExceptionWorkflow;
 use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\TestCase;
 use Workflow\Serializers\Y;
@@ -31,7 +32,7 @@ final class ExceptionWorkflowTest extends TestCase
 
     public function testNonRetryableException(): void
     {
-        $workflow = WorkflowStub::make(NonRetryableTestExceptionActivity::class);
+        $workflow = WorkflowStub::make(NonRetryableTestExceptionWorkflow::class);
 
         $workflow->start();
 

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Workflow\WorkflowStub;
-use Workflow\Serializers\Y;
-use Tests\Fixtures\TestExceptionWorkflow;
-use Workflow\States\WorkflowFailedStatus;
-use Workflow\States\WorkflowCompletedStatus;
 use Tests\Fixtures\NonRetryableTestExceptionActivity;
+use Tests\Fixtures\TestExceptionWorkflow;
+use Tests\TestCase;
+use Workflow\Serializers\Y;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\States\WorkflowFailedStatus;
+use Workflow\WorkflowStub;
 
 final class ExceptionWorkflowTest extends TestCase
 {
@@ -40,7 +40,10 @@ final class ExceptionWorkflowTest extends TestCase
         $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
         $this->assertNotNull($workflow->exceptions()->first());
         $this->assertNull($workflow->output());
-        $this->assertSame('This is a non-retryable error', Y::unserialize($workflow->exceptions()->first()->exception)['message']);
+        $this->assertSame(
+            'This is a non-retryable error',
+            Y::unserialize($workflow->exceptions()->first()->exception)['message']
+        );
 
         $this->assertCount(1, $workflow->exceptions());
     }

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use Tests\Fixtures\NonRetryableTestExceptionActivity;
 use Tests\Fixtures\NonRetryableTestExceptionWorkflow;
 use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\TestCase;

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -42,9 +42,7 @@ final class ExceptionWorkflowTest extends TestCase
         $this->assertNull($workflow->output());
         $this->assertSame(
             'This is a non-retryable error',
-            Y::unserialize($workflow->exceptions()->first()->exception)['message']
+            Y::unserialize($workflow->exceptions()->last()->exception)['message']
         );
-
-        $this->assertCount(1, $workflow->exceptions());
     }
 }

--- a/tests/Fixtures/NonRetryableTestExceptionActivity.php
+++ b/tests/Fixtures/NonRetryableTestExceptionActivity.php
@@ -11,6 +11,6 @@ final class NonRetryableTestExceptionActivity extends Activity
 {
     public function execute()
     {
-        throw new NonRetryableException("This is a non-retryable error");
+        throw new NonRetryableException('This is a non-retryable error');
     }
 }

--- a/tests/Fixtures/NonRetryableTestExceptionActivity.php
+++ b/tests/Fixtures/NonRetryableTestExceptionActivity.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+use Workflow\Exceptions\NonRetryableException;
+
+final class NonRetryableTestExceptionActivity extends Activity
+{
+    public function execute()
+    {
+        throw new NonRetryableException("This is a non-retryable error");
+    }
+}

--- a/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
+++ b/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Workflow\Workflow;
 use Workflow\ActivityStub;
-use Tests\Fixtures\TestActivity;
-use Tests\Fixtures\NonRetryableTestExceptionActivity;
+use Workflow\Workflow;
 
 final class NonRetryableTestExceptionWorkflow extends Workflow
 {

--- a/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
+++ b/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
-use Workflow\ActivityStub;
 use Workflow\Workflow;
+use Workflow\ActivityStub;
+use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\NonRetryableTestExceptionActivity;
 
 final class NonRetryableTestExceptionWorkflow extends Workflow
 {
     public function execute()
     {
         yield ActivityStub::make(NonRetryableTestExceptionActivity::class);
+        yield ActivityStub::make(TestActivity::class);
 
         return 'Workflow completes';
     }

--- a/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
+++ b/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+
+final class NonRetryableTestExceptionWorkflow extends Workflow
+{
+    public function execute()
+    {
+        yield ActivityStub::make(NonRetryableTestExceptionActivity::class);
+
+        return "Workflow completes";
+    }
+}

--- a/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
+++ b/tests/Fixtures/NonRetryableTestExceptionWorkflow.php
@@ -13,6 +13,6 @@ final class NonRetryableTestExceptionWorkflow extends Workflow
     {
         yield ActivityStub::make(NonRetryableTestExceptionActivity::class);
 
-        return "Workflow completes";
+        return 'Workflow completes';
     }
 }


### PR DESCRIPTION
The PR adds NonRetryableException.

When this exception is thrown, The Activity will not retry and The Workflow Marks as Fail.

This implementation will work similarly to Cloudflare Workflow NonRetryableError

[NonRetryableException](https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/#force-a-workflow-to-fail)