### PR TITLE
feat: passing previous exception to exception thrown from workflow

### DIFF
--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -211,7 +211,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
             try {
                 $return = $this->coroutine->getReturn();
             } catch (Throwable $th) {
-                throw new Exception('Workflow failed.');
+                throw new Exception('Workflow failed.', 0, $th);
             }
 
             $this->storedWorkflow->output = Y::serialize($return);


### PR DESCRIPTION
When something is broken with Workflow, we sometimes receive just 'Workflow failed' in logs/failed jobs, without any future explanations. That will pass also information about previous exception, which was cause of that issue