### PR TITLE
Add base64 serializer (#196)

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -22,7 +22,7 @@ use Workflow\Exceptions\NonRetryableExceptionContract;
 use Workflow\Middleware\ActivityMiddleware;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 
 class Activity implements ShouldBeEncrypted, ShouldQueue
 {
@@ -91,7 +91,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
             $this->storedWorkflow->exceptions()
                 ->create([
                     'class' => $this::class,
-                    'exception' => Y::serialize($throwable),
+                    'exception' => Serializer::serialize($throwable),
                 ]);
 
             if ($throwable instanceof NonRetryableExceptionContract) {
@@ -129,7 +129,7 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
             'line' => $throwable->getLine(),
             'file' => $throwable->getFile(),
             'trace' => collect($throwable->getTrace())
-                ->filter(static fn ($trace) => Y::serializable($trace))
+                ->filter(static fn ($trace) => Serializer::serializable($trace))
                 ->toArray(),
             'snippet' => array_slice(iterator_to_array($iterator), 0, 7),
         ];

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -10,7 +10,7 @@ use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Throwable;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 
 final class ActivityStub
 {
@@ -43,7 +43,9 @@ final class ActivityStub
                         'index' => $context->index,
                         'now' => $context->now,
                         'class' => $activity,
-                        'result' => Y::serialize(is_callable($result) ? $result($context, ...$arguments) : $result),
+                        'result' => Serializer::serialize(
+                            is_callable($result) ? $result($context, ...$arguments) : $result
+                        ),
                     ]);
 
                 WorkflowStub::recordDispatched($activity, $arguments);
@@ -53,7 +55,7 @@ final class ActivityStub
         if ($log) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            $result = Y::unserialize($log->result);
+            $result = Serializer::unserialize($log->result);
             if (
                 is_array($result) &&
                 array_key_exists('class', $result) &&

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -8,7 +8,7 @@ use function React\Promise\all;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 
 final class ChildWorkflowStub
 {
@@ -36,7 +36,9 @@ final class ChildWorkflowStub
                         'index' => $context->index,
                         'now' => $context->now,
                         'class' => $workflow,
-                        'result' => Y::serialize(is_callable($result) ? $result($context, ...$arguments) : $result),
+                        'result' => Serializer::serialize(
+                            is_callable($result) ? $result($context, ...$arguments) : $result
+                        ),
                     ]);
 
                 WorkflowStub::recordDispatched($workflow, $arguments);
@@ -46,7 +48,7 @@ final class ChildWorkflowStub
         if ($log) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            return resolve(Y::unserialize($log->result));
+            return resolve(Serializer::unserialize($log->result));
         }
 
         if (! $context->replaying) {

--- a/src/Serializers/AbstractSerializer.php
+++ b/src/Serializers/AbstractSerializer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Serializers;
+
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Laravel\SerializableClosure\SerializableClosure;
+use Throwable;
+
+abstract class AbstractSerializer implements SerializerInterface
+{
+    use SerializesAndRestoresModelIdentifiers;
+
+    abstract public static function getInstance(): self;
+
+    abstract public static function encode(string $data): string;
+
+    abstract public static function decode(string $data): string;
+
+    public static function serializable($data): bool
+    {
+        try {
+            serialize($data);
+            return true;
+        } catch (\Throwable $th) {
+            return false;
+        }
+    }
+
+    public static function serializeModels($data)
+    {
+        if (is_array($data)) {
+            $self = static::getInstance();
+            foreach ($data as $key => $value) {
+                $data[$key] = $self->getSerializedPropertyValue($value);
+            }
+        } elseif ($data instanceof Throwable) {
+            $data = [
+                'class' => get_class($data),
+                'message' => $data->getMessage(),
+                'code' => $data->getCode(),
+                'line' => $data->getLine(),
+                'file' => $data->getFile(),
+                'trace' => collect($data->getTrace())
+                    ->filter(static fn ($trace) => static::serializable($trace))
+                    ->toArray(),
+            ];
+        }
+        return $data;
+    }
+
+    public static function unserializeModels($data)
+    {
+        if (is_array($data)) {
+            $self = static::getInstance();
+            foreach ($data as $key => $value) {
+                $data[$key] = $self->getRestoredPropertyValue($value);
+            }
+        }
+        return $data;
+    }
+
+    public static function serialize($data): string
+    {
+        SerializableClosure::setSecretKey(config('app.key'));
+        $data = static::serializeModels($data);
+        return static::encode(serialize(new SerializableClosure(static fn () => $data)));
+    }
+
+    public static function unserialize(string $data)
+    {
+        SerializableClosure::setSecretKey(config('app.key'));
+        $unserialized = unserialize(static::decode($data));
+        if ($unserialized instanceof SerializableClosure) {
+            $unserialized = ($unserialized->getClosure())();
+        }
+        return static::unserializeModels($unserialized);
+    }
+}

--- a/src/Serializers/Base64.php
+++ b/src/Serializers/Base64.php
@@ -22,11 +22,11 @@ final class Base64 extends AbstractSerializer
 
     public static function encode(string $data): string
     {
-        return base64_encode($data);
+        return 'base64:' . base64_encode($data);
     }
 
     public static function decode(string $data): string
     {
-        return base64_decode($data, true);
+        return base64_decode(substr($data, 7), true);
     }
 }

--- a/src/Serializers/Base64.php
+++ b/src/Serializers/Base64.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Serializers;
+
+final class Base64 extends AbstractSerializer
+{
+    private static ?self $instance = null;
+
+    private function __construct()
+    {
+    }
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public static function encode(string $data): string
+    {
+        return base64_encode($data);
+    }
+
+    public static function decode(string $data): string
+    {
+        return base64_decode($data, true);
+    }
+}

--- a/src/Serializers/Serializer.php
+++ b/src/Serializers/Serializer.php
@@ -17,6 +17,6 @@ final class Serializer
 
     public static function make(): AbstractSerializer
     {
-        return config('workflow.serializer', Y::class)::getInstance();
+        return config('serializer', Y::class)::getInstance();
     }
 }

--- a/src/Serializers/Serializer.php
+++ b/src/Serializers/Serializer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Serializers;
+
+final class Serializer
+{
+    public static function __callStatic(string $name, array $arguments)
+    {
+        $instance = static::make();
+
+        if (method_exists($instance, $name)) {
+            return $instance->{$name}(...$arguments);
+        }
+    }
+
+    public static function make(): AbstractSerializer
+    {
+        return config('workflow.serializer', Y::class)::getInstance();
+    }
+}

--- a/src/Serializers/Serializer.php
+++ b/src/Serializers/Serializer.php
@@ -8,15 +8,18 @@ final class Serializer
 {
     public static function __callStatic(string $name, array $arguments)
     {
-        $instance = static::make();
+        if ($name === 'unserialize') {
+            if (str_starts_with($arguments[0], 'base64:')) {
+                $instance = Base64::getInstance();
+            } else {
+                $instance = Y::getInstance();
+            }
+        } else {
+            $instance = config('serializer', Y::class)::getInstance();
+        }
 
         if (method_exists($instance, $name)) {
             return $instance->{$name}(...$arguments);
         }
-    }
-
-    public static function make(): AbstractSerializer
-    {
-        return config('serializer', Y::class)::getInstance();
     }
 }

--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -8,7 +8,7 @@ use Carbon\CarbonInterval;
 use Illuminate\Database\QueryException;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 
 trait AwaitWithTimeouts
@@ -21,7 +21,7 @@ trait AwaitWithTimeouts
 
         if ($log) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve(Serializer::unserialize($log->result));
         }
 
         if (is_string($seconds)) {
@@ -38,7 +38,7 @@ trait AwaitWithTimeouts
                             'index' => self::$context->index,
                             'now' => self::$context->now,
                             'class' => Signal::class,
-                            'result' => Y::serialize($result),
+                            'result' => Serializer::serialize($result),
                         ]);
                 } catch (QueryException $exception) {
                     $log = self::$context->storedWorkflow->logs()
@@ -47,7 +47,7 @@ trait AwaitWithTimeouts
 
                     if ($log) {
                         ++self::$context->index;
-                        return resolve(Y::unserialize($log->result));
+                        return resolve(Serializer::unserialize($log->result));
                     }
                 }
             }

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -8,7 +8,7 @@ use Illuminate\Database\QueryException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 
 trait Awaits
@@ -21,7 +21,7 @@ trait Awaits
 
         if ($log) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve(Serializer::unserialize($log->result));
         }
 
         $result = $condition();
@@ -34,7 +34,7 @@ trait Awaits
                             'index' => self::$context->index,
                             'now' => self::$context->now,
                             'class' => Signal::class,
-                            'result' => Y::serialize($result),
+                            'result' => Serializer::serialize($result),
                         ]);
                 } catch (QueryException $exception) {
                     $log = self::$context->storedWorkflow->logs()
@@ -43,7 +43,7 @@ trait Awaits
 
                     if ($log) {
                         ++self::$context->index;
-                        return resolve(Y::unserialize($log->result));
+                        return resolve(Serializer::unserialize($log->result));
                     }
                 }
             }

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -7,7 +7,7 @@ namespace Workflow\Traits;
 use Illuminate\Database\QueryException;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 
 trait SideEffects
 {
@@ -19,7 +19,7 @@ trait SideEffects
 
         if ($log) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve(Serializer::unserialize($log->result));
         }
 
         $result = $callable();
@@ -31,7 +31,7 @@ trait SideEffects
                         'index' => self::$context->index,
                         'now' => self::$context->now,
                         'class' => self::$context->storedWorkflow->class,
-                        'result' => Y::serialize($result),
+                        'result' => Serializer::serialize($result),
                     ]);
             } catch (QueryException $exception) {
                 $log = self::$context->storedWorkflow->logs()
@@ -40,7 +40,7 @@ trait SideEffects
 
                 if ($log) {
                     ++self::$context->index;
-                    return resolve(Y::unserialize($log->result));
+                    return resolve(Serializer::unserialize($log->result));
                 }
             }
         }

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -9,7 +9,7 @@ use Illuminate\Database\QueryException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 
 trait Timers
@@ -31,7 +31,7 @@ trait Timers
 
         if ($log) {
             ++self::$context->index;
-            return resolve(Y::unserialize($log->result));
+            return resolve(Serializer::unserialize($log->result));
         }
 
         $timer = self::$context->storedWorkflow->timers()
@@ -62,7 +62,7 @@ trait Timers
                             'index' => self::$context->index,
                             'now' => self::$context->now,
                             'class' => Signal::class,
-                            'result' => Y::serialize(true),
+                            'result' => Serializer::serialize(true),
                         ]);
                 } catch (QueryException $exception) {
                     // already logged

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -21,7 +21,7 @@ use Throwable;
 use Workflow\Events\WorkflowCompleted;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowRunningStatus;
 use Workflow\States\WorkflowWaitingStatus;
@@ -133,7 +133,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                 $query->where('created_at', '<=', $log->created_at->format('Y-m-d H:i:s.u'));
             })
             ->each(function ($signal): void {
-                $this->{$signal->method}(...Y::unserialize($signal->arguments));
+                $this->{$signal->method}(...Serializer::unserialize($signal->arguments));
             });
 
         if ($parentWorkflow) {
@@ -170,7 +170,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                         $query->where('created_at', '<=', $nextLog->created_at->format('Y-m-d H:i:s.u'));
                     })
                     ->each(function ($signal): void {
-                        $this->{$signal->method}(...Y::unserialize($signal->arguments));
+                        $this->{$signal->method}(...Serializer::unserialize($signal->arguments));
                     });
             }
 
@@ -214,7 +214,7 @@ class Workflow implements ShouldBeEncrypted, ShouldQueue
                 throw new Exception('Workflow failed.', 0, $th);
             }
 
-            $this->storedWorkflow->output = Y::serialize($return);
+            $this->storedWorkflow->output = Serializer::serialize($return);
 
             $this->storedWorkflow->status->transitionTo(WorkflowCompletedStatus::class);
 

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -14,7 +14,7 @@ use SplFileObject;
 use Workflow\Events\WorkflowFailed;
 use Workflow\Events\WorkflowStarted;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowCreatedStatus;
 use Workflow\States\WorkflowFailedStatus;
@@ -58,7 +58,7 @@ final class WorkflowStub
             $this->storedWorkflow->signals()
                 ->create([
                     'method' => $method,
-                    'arguments' => Y::serialize($arguments),
+                    'arguments' => Serializer::serialize($arguments),
                 ]);
 
             $this->storedWorkflow->toWorkflow();
@@ -79,7 +79,7 @@ final class WorkflowStub
         ) {
             return (new $this->storedWorkflow->class(
                 $this->storedWorkflow,
-                ...Y::unserialize($this->storedWorkflow->arguments),
+                ...Serializer::unserialize($this->storedWorkflow->arguments),
             ))
                 ->query($method);
         }
@@ -155,7 +155,7 @@ final class WorkflowStub
             return null;
         }
 
-        return Y::unserialize($this->storedWorkflow->fresh()->output);
+        return Serializer::unserialize($this->storedWorkflow->fresh()->output);
     }
 
     public function completed(): bool
@@ -199,7 +199,7 @@ final class WorkflowStub
 
     public function start(...$arguments): void
     {
-        $this->storedWorkflow->arguments = Y::serialize($arguments);
+        $this->storedWorkflow->arguments = Serializer::serialize($arguments);
 
         $this->dispatch();
     }
@@ -224,7 +224,7 @@ final class WorkflowStub
             $this->storedWorkflow->exceptions()
                 ->create([
                     'class' => $this->storedWorkflow->class,
-                    'exception' => Y::serialize($exception),
+                    'exception' => Serializer::serialize($exception),
                 ]);
         } catch (QueryException) {
             // already logged
@@ -265,7 +265,7 @@ final class WorkflowStub
                     'index' => $index,
                     'now' => $now,
                     'class' => $class,
-                    'result' => Y::serialize($result),
+                    'result' => Serializer::serialize($result),
                 ]);
         } catch (QueryException) {
             // already logged
@@ -280,7 +280,7 @@ final class WorkflowStub
             WorkflowStarted::dispatch(
                 $this->storedWorkflow->id,
                 $this->storedWorkflow->class,
-                json_encode(Y::unserialize($this->storedWorkflow->arguments)),
+                json_encode(Serializer::unserialize($this->storedWorkflow->arguments)),
                 now()
                     ->format('Y-m-d\TH:i:s.u\Z')
             );
@@ -292,7 +292,7 @@ final class WorkflowStub
 
         $this->storedWorkflow->class::$dispatch(
             $this->storedWorkflow,
-            ...Y::unserialize($this->storedWorkflow->arguments)
+            ...Serializer::unserialize($this->storedWorkflow->arguments)
         );
     }
 }

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -19,6 +19,8 @@ return [
 
     'workflow_relationships_table' => 'workflow_relationships',
 
+    'workflow_serializer' => Workflow\Serializers\Y::class,
+
     'prune_age' => '1 month',
 
     'monitor' => env('WORKFLOW_MONITOR', false),

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -19,7 +19,7 @@ return [
 
     'workflow_relationships_table' => 'workflow_relationships',
 
-    'workflow_serializer' => Workflow\Serializers\Y::class,
+    'serializer' => Workflow\Serializers\Y::class,
 
     'prune_age' => '1 month',
 

--- a/tests/Feature/Base64WorkflowTest.php
+++ b/tests/Feature/Base64WorkflowTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestExceptionWorkflow;
+use Tests\TestCase;
+use Workflow\Serializers\Base64;
+use Workflow\Serializers\Serializer;
+use Workflow\Serializers\Y;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+final class Base64WorkflowTest extends TestCase
+{
+    public function testBase64ToY(): void
+    {
+        config([
+            'serializer' => Base64::class,
+        ]);
+
+        $workflow = WorkflowStub::make(TestExceptionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+
+        config([
+            'serializer' => Y::class,
+        ]);
+
+        if ($workflow->exceptions()->first()) {
+            $this->assertSame(
+                'failed',
+                Serializer::unserialize($workflow->exceptions()->first()->exception)['message']
+            );
+        }
+    }
+
+    public function testYToBase64(): void
+    {
+        config([
+            'serializer' => Y::class,
+        ]);
+
+        $workflow = WorkflowStub::make(TestExceptionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+
+        config([
+            'serializer' => Base64::class,
+        ]);
+
+        if ($workflow->exceptions()->first()) {
+            $this->assertSame(
+                'failed',
+                Serializer::unserialize($workflow->exceptions()->first()->exception)['message']
+            );
+        }
+    }
+}

--- a/tests/Feature/ExceptionWorkflowTest.php
+++ b/tests/Feature/ExceptionWorkflowTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature;
 use Tests\Fixtures\NonRetryableTestExceptionWorkflow;
 use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\TestCase;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
@@ -25,7 +25,10 @@ final class ExceptionWorkflowTest extends TestCase
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
         if ($workflow->exceptions()->first()) {
-            $this->assertSame('failed', Y::unserialize($workflow->exceptions()->first()->exception)['message']);
+            $this->assertSame(
+                'failed',
+                Serializer::unserialize($workflow->exceptions()->first()->exception)['message']
+            );
         }
     }
 
@@ -42,7 +45,7 @@ final class ExceptionWorkflowTest extends TestCase
         $this->assertNull($workflow->output());
         $this->assertSame(
             'This is a non-retryable error',
-            Y::unserialize($workflow->exceptions()->last()->exception)['message']
+            Serializer::unserialize($workflow->exceptions()->last()->exception)['message']
         );
     }
 }

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -10,7 +10,7 @@ use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\ActivityStub;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
@@ -21,7 +21,7 @@ final class ActivityStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
@@ -39,7 +39,7 @@ final class ActivityStubTest extends TestCase
             'index' => 0,
             'class' => TestActivity::class,
         ]);
-        $this->assertSame('activity', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame('activity', Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -47,7 +47,7 @@ final class ActivityStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -55,7 +55,7 @@ final class ActivityStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         ActivityStub::make(TestActivity::class)
@@ -73,7 +73,7 @@ final class ActivityStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -81,7 +81,7 @@ final class ActivityStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize(new Exception('test')),
+                'result' => Serializer::serialize(new Exception('test')),
             ]);
 
         ActivityStub::make(TestActivity::class)
@@ -97,7 +97,7 @@ final class ActivityStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -105,7 +105,7 @@ final class ActivityStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         ActivityStub::all([ActivityStub::make(TestActivity::class)])
@@ -121,7 +121,7 @@ final class ActivityStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -129,7 +129,7 @@ final class ActivityStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         ActivityStub::async(static function () {

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -12,7 +12,7 @@ use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCreatedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\WorkflowStub;
@@ -87,7 +87,7 @@ final class ActivityTest extends TestCase
             'index' => 0,
             'now' => now(),
             'class' => TestOtherActivity::class,
-            'result' => Y::serialize('other'),
+            'result' => Serializer::serialize('other'),
         ]);
         $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), [
             'other',

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -9,7 +9,7 @@ use Tests\Fixtures\TestParentWorkflow;
 use Tests\TestCase;
 use Workflow\ChildWorkflowStub;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
 
@@ -20,7 +20,7 @@ final class ChildWorkflowStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
@@ -39,7 +39,7 @@ final class ChildWorkflowStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -47,7 +47,7 @@ final class ChildWorkflowStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestParentWorkflow::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         ChildWorkflowStub::make(TestChildWorkflow::class)
@@ -63,14 +63,14 @@ final class ChildWorkflowStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
         $childWorkflow = WorkflowStub::load(WorkflowStub::make(TestChildWorkflow::class)->id());
         $storedChildWorkflow = StoredWorkflow::findOrFail($childWorkflow->id());
         $storedChildWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedChildWorkflow->parents()
@@ -94,7 +94,7 @@ final class ChildWorkflowStubTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->logs()
@@ -102,7 +102,7 @@ final class ChildWorkflowStubTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestParentWorkflow::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         ChildWorkflowStub::all([ChildWorkflowStub::make(TestChildWorkflow::class)])

--- a/tests/Unit/Serializers/EncodeTest.php
+++ b/tests/Unit/Serializers/EncodeTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Serializers;
 
 use Tests\TestCase;
+use Workflow\Serializers\Base64;
+use Workflow\Serializers\Serializer;
 use Workflow\Serializers\Y;
 
 final class EncodeTest extends TestCase
@@ -12,9 +14,20 @@ final class EncodeTest extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testEncode(string $bytes): void
+    public function testYEncode(string $bytes): void
     {
-        $decoded = Y::decode(Y::encode($bytes));
+        config('workflow_serializer', Y::class);
+        $decoded = Serializer::decode(Serializer::encode($bytes));
+        $this->assertSame($bytes, $decoded);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testBase64Encode(string $bytes): void
+    {
+        config('workflow_serializer', Base64::class);
+        $decoded = Serializer::decode(Serializer::encode($bytes));
         $this->assertSame($bytes, $decoded);
     }
 
@@ -25,15 +38,15 @@ final class EncodeTest extends TestCase
             'foo' => ['foo'],
             'bytes' => [random_bytes(4096)],
             'bytes x2' => [random_bytes(8192)],
-            'null' => ['\x00'],
-            'null x2' => ['\x00\x00'],
-            'escape x2' => ['\x01\01'],
-            'null escape' => ['\x00\x01'],
-            'escape next' => ['\x01\x02'],
-            'null escape x2' => ['\x00\x01\x00\x01'],
-            'escape next x2' => ['\x01\x02\x01\x02'],
-            'escape null escape next' => ['\x01\x00\x01\x02'],
-            'next escape null escape' => ['\x02\x01\x00\x01'],
+            'null' => [chr(0)],
+            'null x2' => [chr(0) . chr(0)],
+            'escape x2' => [chr(1) . chr(1)],
+            'null escape' => [chr(0) . chr(1)],
+            'escape next' => [chr(1) . chr(2)],
+            'null escape x2' => [chr(0) . chr(1) . chr(0) . chr(1)],
+            'escape next x2' => [chr(1) . chr(2) . chr(1) . chr(2)],
+            'escape null escape next' => [chr(1) . chr(0) . chr(1) . chr(2)],
+            'next escape null escape' => [chr(2) . chr(1) . chr(0) . chr(1)],
         ];
     }
 }

--- a/tests/Unit/Serializers/EncodeTest.php
+++ b/tests/Unit/Serializers/EncodeTest.php
@@ -16,7 +16,9 @@ final class EncodeTest extends TestCase
      */
     public function testYEncode(string $bytes): void
     {
-        config('workflow_serializer', Y::class);
+        config([
+            'serializer' => Y::class,
+        ]);
         $decoded = Serializer::decode(Serializer::encode($bytes));
         $this->assertSame($bytes, $decoded);
     }
@@ -26,7 +28,9 @@ final class EncodeTest extends TestCase
      */
     public function testBase64Encode(string $bytes): void
     {
-        config('workflow_serializer', Base64::class);
+        config([
+            'serializer' => Base64::class,
+        ]);
         $decoded = Serializer::decode(Serializer::encode($bytes));
         $this->assertSame($bytes, $decoded);
     }

--- a/tests/Unit/Serializers/SerializeTest.php
+++ b/tests/Unit/Serializers/SerializeTest.php
@@ -16,23 +16,12 @@ final class SerializeTest extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testYSerialize($data): void
+    public function testSerialize($data): void
     {
-        config([
-            'serializer' => Y::class,
-        ]);
-        $this->testSerialize($data);
-    }
-
-    /**
-     * @dataProvider dataProvider
-     */
-    public function testBase64Serialize($data): void
-    {
-        config([
-            'serializer' => Base64::class,
-        ]);
-        $this->testSerialize($data);
+        $this->testSerializeUnserialize($data, Y::class, Y::class);
+        $this->testSerializeUnserialize($data, Base64::class, Base64::class);
+        $this->testSerializeUnserialize($data, Y::class, Base64::class);
+        $this->testSerializeUnserialize($data, Base64::class, Y::class);
     }
 
     public function dataProvider(): array
@@ -67,9 +56,16 @@ final class SerializeTest extends TestCase
         ];
     }
 
-    private function testSerialize($data): void
+    private function testSerializeUnserialize($data, $serializer, $unserializer): void
     {
-        $unserialized = Serializer::unserialize(Serializer::serialize($data));
+        config([
+            'serializer' => $serializer,
+        ]);
+        $serialized = Serializer::serialize($data);
+        config([
+            'serializer' => $unserializer,
+        ]);
+        $unserialized = Serializer::unserialize($serialized);
         if (is_object($data)) {
             if ($data instanceof Throwable) {
                 $this->assertEquals([

--- a/tests/Unit/Serializers/SerializeTest.php
+++ b/tests/Unit/Serializers/SerializeTest.php
@@ -18,7 +18,9 @@ final class SerializeTest extends TestCase
      */
     public function testYSerialize($data): void
     {
-        config('workflow_serializer', Y::class);
+        config([
+            'serializer' => Y::class,
+        ]);
         $this->testSerialize($data);
     }
 
@@ -27,7 +29,9 @@ final class SerializeTest extends TestCase
      */
     public function testBase64Serialize($data): void
     {
-        config('workflow_serializer', Base64::class);
+        config([
+            'serializer' => Base64::class,
+        ]);
         $this->testSerialize($data);
     }
 

--- a/tests/Unit/Traits/AwaitWithTimeoutsTest.php
+++ b/tests/Unit/Traits/AwaitWithTimeoutsTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
@@ -19,7 +19,7 @@ final class AwaitWithTimeoutsTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
@@ -56,7 +56,7 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -68,7 +68,7 @@ final class AwaitWithTimeoutsTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => Signal::class,
-                'result' => Y::serialize(true),
+                'result' => Serializer::serialize(true),
             ]);
 
         WorkflowStub::awaitWithTimeout('1 minute', static fn () => true)
@@ -83,7 +83,7 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -97,7 +97,7 @@ final class AwaitWithTimeoutsTest extends TestCase
                     'index' => 0,
                     'now' => WorkflowStub::now(),
                     'class' => Signal::class,
-                    'result' => Y::serialize(false),
+                    'result' => Serializer::serialize(false),
                 ]);
             return true;
         })
@@ -112,6 +112,6 @@ final class AwaitWithTimeoutsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertFalse(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertFalse(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 }

--- a/tests/Unit/Traits/AwaitsTest.php
+++ b/tests/Unit/Traits/AwaitsTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 use Workflow\WorkflowStub;
 
@@ -42,7 +42,7 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -54,7 +54,7 @@ final class AwaitsTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => Signal::class,
-                'result' => Y::serialize(true),
+                'result' => Serializer::serialize(true),
             ]);
 
         WorkflowStub::await(static fn () => true)
@@ -69,7 +69,7 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -83,7 +83,7 @@ final class AwaitsTest extends TestCase
                     'index' => 0,
                     'now' => WorkflowStub::now(),
                     'class' => Signal::class,
-                    'result' => Y::serialize(false),
+                    'result' => Serializer::serialize(false),
                 ]);
             return true;
         })
@@ -98,6 +98,6 @@ final class AwaitsTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertFalse(Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertFalse(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 }

--- a/tests/Unit/Traits/SideEffectsTest.php
+++ b/tests/Unit/Traits/SideEffectsTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\WorkflowStub;
 
 final class SideEffectsTest extends TestCase
@@ -28,7 +28,7 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame('test', Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -40,7 +40,7 @@ final class SideEffectsTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestWorkflow::class,
-                'result' => Y::serialize('test'),
+                'result' => Serializer::serialize('test'),
             ]);
 
         WorkflowStub::sideEffect(static fn () => '')
@@ -55,7 +55,7 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame('test', Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testResolvesConflictingResult(): void
@@ -69,7 +69,7 @@ final class SideEffectsTest extends TestCase
                     'index' => 0,
                     'now' => WorkflowStub::now(),
                     'class' => TestWorkflow::class,
-                    'result' => Y::serialize('test'),
+                    'result' => Serializer::serialize('test'),
                 ]);
             return '';
         })
@@ -84,6 +84,6 @@ final class SideEffectsTest extends TestCase
             'index' => 0,
             'class' => TestWorkflow::class,
         ]);
-        $this->assertSame('test', Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame('test', Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 }

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Traits;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
@@ -32,7 +32,7 @@ final class TimersTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
@@ -55,7 +55,7 @@ final class TimersTest extends TestCase
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
         $storedWorkflow->timers()
@@ -104,7 +104,7 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertSame(true, Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame(true, Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
     public function testLoadsStoredResult(): void
@@ -121,7 +121,7 @@ final class TimersTest extends TestCase
                 'index' => 0,
                 'now' => now(),
                 'class' => Signal::class,
-                'result' => Y::serialize(true),
+                'result' => Serializer::serialize(true),
             ]);
 
         WorkflowStub::timer('1 minute', static fn () => true)
@@ -136,6 +136,6 @@ final class TimersTest extends TestCase
             'index' => 0,
             'class' => Signal::class,
         ]);
-        $this->assertSame(true, Y::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+        $this->assertSame(true, Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 }

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -11,7 +11,7 @@ use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\Signal;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
@@ -26,7 +26,7 @@ final class WorkflowStubTest extends TestCase
         $parentWorkflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedParentWorkflow = StoredWorkflow::findOrFail($parentWorkflow->id());
         $storedParentWorkflow->update([
-            'arguments' => Y::serialize([]),
+            'arguments' => Serializer::serialize([]),
             'status' => WorkflowPendingStatus::$name,
         ]);
 
@@ -105,7 +105,7 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 1)->result));
 
         $workflow->fresh();
         $context = WorkflowStub::getContext();
@@ -144,7 +144,7 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 1)->result));
 
         $workflow->fresh();
         $context = WorkflowStub::getContext();
@@ -192,7 +192,7 @@ final class WorkflowStubTest extends TestCase
             'index' => 1,
             'class' => Signal::class,
         ]);
-        $this->assertTrue(Y::unserialize($workflow->logs()->firstWhere('index', 1)->result));
+        $this->assertTrue(Serializer::unserialize($workflow->logs()->firstWhere('index', 1)->result));
     }
 
     public function testConnection(): void

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -13,7 +13,7 @@ use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
 use Workflow\Models\StoredWorkflow;
-use Workflow\Serializers\Y;
+use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCompletedStatus;
 use Workflow\States\WorkflowPendingStatus;
 use Workflow\WorkflowStub;
@@ -25,7 +25,7 @@ final class WorkflowTest extends TestCase
         $exception = new \Exception('test');
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
-        $storedWorkflow->arguments = Y::serialize([]);
+        $storedWorkflow->arguments = Serializer::serialize([]);
         $storedWorkflow->save();
         $activity = new Exception(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(
             $workflow->id()
@@ -41,7 +41,7 @@ final class WorkflowTest extends TestCase
         $exception = new \Exception('test');
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
-        $storedWorkflow->arguments = Y::serialize([]);
+        $storedWorkflow->arguments = Serializer::serialize([]);
         $storedWorkflow->save();
         $activity = new Exception(0, now()->toDateTimeString(), StoredWorkflow::findOrFail(
             $workflow->id()
@@ -52,7 +52,7 @@ final class WorkflowTest extends TestCase
                 'index' => 0,
                 'now' => WorkflowStub::now(),
                 'class' => TestOtherActivity::class,
-                'result' => Y::serialize($exception),
+                'result' => Serializer::serialize($exception),
             ]);
 
         $activity->handle();
@@ -67,7 +67,7 @@ final class WorkflowTest extends TestCase
         $parentWorkflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
 
         $storedParentWorkflow = StoredWorkflow::findOrFail($parentWorkflow->id());
-        $storedParentWorkflow->arguments = Y::serialize([]);
+        $storedParentWorkflow->arguments = Serializer::serialize([]);
         $storedParentWorkflow->save();
 
         $storedParentWorkflow->logs()
@@ -75,7 +75,7 @@ final class WorkflowTest extends TestCase
                 'index' => 0,
                 'now' => now(),
                 'class' => TestChildWorkflow::class,
-                'result' => Y::serialize('child_workflow'),
+                'result' => Serializer::serialize('child_workflow'),
             ]);
 
         $storedParentWorkflow->logs()
@@ -83,13 +83,13 @@ final class WorkflowTest extends TestCase
                 'index' => 1,
                 'now' => now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize('activity'),
+                'result' => Serializer::serialize('activity'),
             ]);
 
         $childWorkflow = WorkflowStub::load(WorkflowStub::make(TestChildWorkflow::class)->id());
 
         $storedChildWorkflow = StoredWorkflow::findOrFail($childWorkflow->id());
-        $storedChildWorkflow->arguments = Y::serialize([]);
+        $storedChildWorkflow->arguments = Serializer::serialize([]);
         $storedChildWorkflow->status = WorkflowPendingStatus::class;
         $storedChildWorkflow->save();
         $storedChildWorkflow->parents()
@@ -103,7 +103,7 @@ final class WorkflowTest extends TestCase
                 'index' => 0,
                 'now' => now(),
                 'class' => TestOtherActivity::class,
-                'result' => Y::serialize('other'),
+                'result' => Serializer::serialize('other'),
             ]);
 
         (new (TestChildWorkflow::class)($storedChildWorkflow))->handle();
@@ -121,7 +121,7 @@ final class WorkflowTest extends TestCase
         $parentWorkflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
 
         $storedParentWorkflow = StoredWorkflow::findOrFail($parentWorkflow->id());
-        $storedParentWorkflow->arguments = Y::serialize([]);
+        $storedParentWorkflow->arguments = Serializer::serialize([]);
         $storedParentWorkflow->status = WorkflowPendingStatus::class;
         $storedParentWorkflow->save();
 
@@ -130,7 +130,7 @@ final class WorkflowTest extends TestCase
                 'index' => 0,
                 'now' => now(),
                 'class' => TestChildWorkflow::class,
-                'result' => Y::serialize('child_workflow'),
+                'result' => Serializer::serialize('child_workflow'),
             ]);
 
         $storedParentWorkflow->logs()
@@ -138,13 +138,13 @@ final class WorkflowTest extends TestCase
                 'index' => 1,
                 'now' => now(),
                 'class' => TestActivity::class,
-                'result' => Y::serialize('activity'),
+                'result' => Serializer::serialize('activity'),
             ]);
 
         $childWorkflow = WorkflowStub::load(WorkflowStub::make(TestChildWorkflow::class)->id());
 
         $storedChildWorkflow = StoredWorkflow::findOrFail($childWorkflow->id());
-        $storedChildWorkflow->arguments = Y::serialize([]);
+        $storedChildWorkflow->arguments = Serializer::serialize([]);
         $storedChildWorkflow->status = WorkflowPendingStatus::class;
         $storedChildWorkflow->save();
         $storedChildWorkflow->parents()
@@ -158,7 +158,7 @@ final class WorkflowTest extends TestCase
                 'index' => 0,
                 'now' => now(),
                 'class' => TestOtherActivity::class,
-                'result' => Y::serialize('other'),
+                'result' => Serializer::serialize('other'),
             ]);
 
         (new (TestChildWorkflow::class)($storedChildWorkflow))->handle();


### PR DESCRIPTION
This change allows you to optionally use the base64 serializer instead of Y. The tradeoff is between speed and size. Base64 is faster but adds more overhead. Y is slower but smaller. It defaults to Y to avoid introducing breaking changes. This also assumes you are starting from scratch as switching from Y to Base64 or vice versa once you have generated some workflows is not supported and beyond the scope of this PR.