### PR TITLE
fix: eloquent model import

### DIFF
--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Spatie\ModelStates\HasStates;
 use Workflow\States\WorkflowStatus;

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
  * @extends Illuminate\Database\Eloquent\Model
  */

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
  * @extends Illuminate\Database\Eloquent\Model
  */

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
  * @extends Illuminate\Database\Eloquent\Model
  */

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\Models;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
  * @extends Illuminate\Database\Eloquent\Model
  */


### PR DESCRIPTION
Thank you for this great package. 
When I tested the package within another Laravel package, I got `Class "Workflow\Models\Model" not found`.
I was able to temporarily circumvent the issue by creating an alias in the package's `ServiceProvider` ie:
```php
...
use Illuminate\Database\Eloquent\Model;
...

 if (! class_exists('Workflow\Models\Model')) {
            class_alias(
                Model::class,
                'Workflow\Models\Model'
            );
        }
```
, but it'd be nice not to get the error at all.