### PR TITLE
Webhooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "laravel/framework": "^9.0|^10.0|^11.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
         "spatie/laravel-model-states": "^2.1",
         "react/promise": "^2.9|^3.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
     level: 0
     bootstrapFiles:
         - classAliases.php
+    ignoreErrors:
+        - '#Attribute class Workflow\\Webhook does not have the class target#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,3 @@ parameters:
     level: 0
     bootstrapFiles:
         - classAliases.php
-    ignoreErrors:
-        - '#Attribute class Workflow\\Webhook does not have the class target#'

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 use LimitIterator;
 use SplFileObject;
 use Throwable;
@@ -71,6 +72,17 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     public function workflowId()
     {
         return $this->storedWorkflow->id;
+    }
+
+    public function webhookUrl(string $signalMethod = ''): string
+    {
+        $basePath = config('workflows.webhooks_route', '/webhooks');
+        if ($signalMethod === '') {
+            $workflow = Str::kebab(class_basename($this->storedWorkflow->class));
+            return url("{$basePath}/{$workflow}");
+        }
+        $signal = Str::kebab($signalMethod);
+        return url("{$basePath}/signal/{$this->storedWorkflow->id}/{$signal}");
     }
 
     public function handle()

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final class Webhook
+{
+}

--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -28,7 +28,7 @@ class Webhooks
     {
         $basePath = $customAppPath ?? app_path(Str::replace('\\', '/', $namespace));
         if (! is_dir($basePath)) {
-            return []; // no coverage
+            return [];
         }
 
         $files = self::scanDirectory($basePath);
@@ -75,19 +75,17 @@ class Webhooks
             if ($method->getName() === 'execute') {
                 $slug = Str::kebab(class_basename($workflow));
                 Route::post("{$basePath}/start/{$slug}", static function (Request $request) use ($workflow) {
-                    if (! self::validateAuth($request)) { // no coverage
+                    if (! self::validateAuth($request)) {
                         return response()->json([
-                            // no coverage
-                            'error' => 'Unauthorized', // no coverage
-                        ], 401); // no coverage
-                    } // no coverage
+                            'error' => 'Unauthorized',
+                        ], 401);
+                    }
 
-                    $params = self::resolveNamedParameters($workflow, 'execute', $request->all()); // no coverage
-                    WorkflowStub::make($workflow)->start(...$params); // no coverage
+                    $params = self::resolveNamedParameters($workflow, 'execute', $request->all());
+                    WorkflowStub::make($workflow)->start(...$params);
                     return response()->json([
-                        // no coverage
-                        'message' => 'Workflow started', // no coverage
-                    ]); // no coverage
+                        'message' => 'Workflow started',
+                    ]);
                 });
             }
         }
@@ -103,25 +101,23 @@ class Webhooks
                 Route::post(
                     "{$basePath}/signal/{$slug}/{workflowId}/{$signal}",
                     static function (Request $request, $workflowId) use ($workflow, $method) {
-                        if (! self::validateAuth($request)) { // no coverage
+                        if (! self::validateAuth($request)) {
                             return response()->json([
-                                // no coverage
-                                'error' => 'Unauthorized', // no coverage
-                            ], 401); // no coverage
-                        } // no coverage
+                                'error' => 'Unauthorized',
+                            ], 401);
+                        }
 
-                        $workflowInstance = WorkflowStub::load($workflowId); // no coverage
-                        $params = self::resolveNamedParameters( // no coverage
-                            $workflow, // no coverage
-                            $method->getName(), // no coverage
-                            $request->except('workflow_id') // no coverage
-                        ); // no coverage
-                        $workflowInstance->{$method->getName()}(...$params); // no coverage
+                        $workflowInstance = WorkflowStub::load($workflowId);
+                        $params = self::resolveNamedParameters(
+                            $workflow,
+                            $method->getName(),
+                            $request->except('workflow_id')
+                        );
+                        $workflowInstance->{$method->getName()}(...$params);
 
                         return response()->json([
-                            // no coverage
-                            'message' => 'Signal sent', // no coverage
-                        ]); // no coverage
+                            'message' => 'Signal sent',
+                        ]);
                     }
                 );
             }
@@ -185,6 +181,6 @@ class Webhooks
             return $request->header($header) === $token;
         }
 
-        return false; // no coverage
+        return false;
     }
 }

--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -162,7 +162,7 @@ class Webhooks
 
     private static function validateAuth(Request $request): bool
     {
-        $config = config('workflows.webhook_auth');
+        $config = config('workflows.webhook_auth', ['method' => 'none']);
 
         if ($config['method'] === 'none') {
             return true;

--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -162,7 +162,9 @@ class Webhooks
 
     private static function validateAuth(Request $request): bool
     {
-        $config = config('workflows.webhook_auth', ['method' => 'none']);
+        $config = config('workflows.webhook_auth', [
+            'method' => 'none',
+        ]);
 
         if ($config['method'] === 'none') {
             return true;

--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionMethod;
+
+class Webhooks
+{
+    public static function routes($customNamespace = null, $customAppPath = null)
+    {
+        $folder = config('workflows.workflows_folder', 'Workflows');
+        $namespace = $customNamespace ?? "App\\{$folder}";
+        $basePath = rtrim(config('workflows.webhooks_route', 'webhooks'), '/');
+
+        foreach (self::discoverWorkflows($namespace, $customAppPath) as $workflow) {
+            self::registerWorkflowWebhooks($workflow, $basePath);
+            self::registerSignalWebhooks($workflow, $basePath);
+        }
+    }
+
+    private static function discoverWorkflows($namespace, $customAppPath = null)
+    {
+        $basePath = $customAppPath ?? app_path(Str::replace('\\', '/', $namespace));
+        if (! is_dir($basePath)) {
+            return [];
+        }
+
+        $files = self::scanDirectory($basePath);
+
+        $filter = array_filter(
+            array_map(static fn ($file) => self::getClassFromFile($file, $namespace, $basePath), $files),
+            static fn ($class) => is_subclass_of($class, \Workflow\Workflow::class)
+        );
+
+        return $filter;
+    }
+
+    private static function scanDirectory($directory)
+    {
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory));
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && Str::endsWith($file->getFilename(), '.php')) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        return $files;
+    }
+
+    private static function getClassFromFile($file, $namespace, $basePath)
+    {
+        $relativePath = Str::replaceFirst($basePath . '/', '', $file);
+        $classPath = str_replace(['/', '.php'], ['\\', ''], $relativePath);
+
+        return "{$namespace}\\{$classPath}";
+    }
+
+    private static function registerWorkflowWebhooks($workflow, $basePath)
+    {
+        $reflection = new ReflectionClass($workflow);
+
+        if (! self::hasWebhookAttributeOnClass($reflection)) {
+            return;
+        }
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->getName() === 'execute') {
+                $slug = Str::kebab(class_basename($workflow));
+                Route::post("{$basePath}/start/{$slug}", static function (Request $request) use ($workflow, $method) {
+                    if (! self::validateAuth($request)) {
+                        return response()->json([
+                            'error' => 'Unauthorized',
+                        ], 401);
+                    }
+
+                    $params = self::resolveNamedParameters($workflow, 'execute', $request->all());
+                    WorkflowStub::make($workflow)->start(...$params);
+                    return response()->json([
+                        'message' => 'Workflow started',
+                    ]);
+                });
+            }
+        }
+    }
+
+    private static function registerSignalWebhooks($workflow, $basePath)
+    {
+        foreach (self::getSignalMethods($workflow) as $method) {
+            if (self::hasWebhookAttributeOnMethod($method)) {
+                $slug = Str::kebab(class_basename($workflow));
+                $signal = Str::kebab($method->getName());
+
+                Route::post(
+                    "{$basePath}/signal/{$slug}/{workflowId}/{$signal}",
+                    static function (Request $request, $workflowId) use ($workflow, $method) {
+                        if (! self::validateAuth($request)) {
+                            return response()->json([
+                                'error' => 'Unauthorized',
+                            ], 401);
+                        }
+
+                        $workflowInstance = WorkflowStub::load($workflowId);
+                        $params = self::resolveNamedParameters(
+                            $workflow,
+                            $method->getName(),
+                            $request->except('workflow_id')
+                        );
+                        $workflowInstance->{$method->getName()}(...$params);
+
+                        return response()->json([
+                            'message' => 'Signal sent',
+                        ]);
+                    }
+                );
+            }
+        }
+    }
+
+    private static function getSignalMethods($workflow)
+    {
+        return array_filter(
+            (new ReflectionClass($workflow))->getMethods(ReflectionMethod::IS_PUBLIC),
+            static fn ($method) => count($method->getAttributes(\Workflow\SignalMethod::class)) > 0
+        );
+    }
+
+    private static function hasWebhookAttributeOnClass(ReflectionClass $class): bool
+    {
+        return count($class->getAttributes(Webhook::class)) > 0;
+    }
+
+    private static function hasWebhookAttributeOnMethod(ReflectionMethod $method): bool
+    {
+        return count($method->getAttributes(Webhook::class)) > 0;
+    }
+
+    private static function resolveNamedParameters($class, $method, $payload)
+    {
+        $reflection = new ReflectionClass($class);
+        $method = $reflection->getMethod($method);
+        $params = [];
+
+        foreach ($method->getParameters() as $param) {
+            $name = $param->getName();
+            if (array_key_exists($name, $payload)) {
+                $params[$name] = $payload[$name];
+            } elseif ($param->isDefaultValueAvailable()) {
+                $params[$name] = $param->getDefaultValue();
+            }
+        }
+
+        return $params;
+    }
+
+    private static function validateAuth(Request $request): bool
+    {
+        $config = config('workflows.webhook_auth');
+
+        if ($config['method'] === 'none') {
+            return true;
+        }
+
+        if ($config['method'] === 'signature') {
+            $secret = $config['signature']['secret'];
+            $header = $config['signature']['header'];
+            $expectedSignature = hash_hmac('sha256', $request->getContent(), $secret);
+            return $request->header($header) === $expectedSignature;
+        }
+
+        if ($config['method'] === 'token') {
+            $token = $config['token']['token'];
+            $header = $config['token']['header'];
+            return $request->header($header) === $token;
+        }
+
+        return false;
+    }
+}

--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -28,7 +28,7 @@ class Webhooks
     {
         $basePath = $customAppPath ?? app_path(Str::replace('\\', '/', $namespace));
         if (! is_dir($basePath)) {
-            return [];
+            return []; // no coverage
         }
 
         $files = self::scanDirectory($basePath);
@@ -74,18 +74,20 @@ class Webhooks
         foreach ($reflection->getMethods() as $method) {
             if ($method->getName() === 'execute') {
                 $slug = Str::kebab(class_basename($workflow));
-                Route::post("{$basePath}/start/{$slug}", static function (Request $request) use ($workflow, $method) {
-                    if (! self::validateAuth($request)) {
+                Route::post("{$basePath}/start/{$slug}", static function (Request $request) use ($workflow) {
+                    if (! self::validateAuth($request)) { // no coverage
                         return response()->json([
-                            'error' => 'Unauthorized',
-                        ], 401);
-                    }
+                            // no coverage
+                            'error' => 'Unauthorized', // no coverage
+                        ], 401); // no coverage
+                    } // no coverage
 
-                    $params = self::resolveNamedParameters($workflow, 'execute', $request->all());
-                    WorkflowStub::make($workflow)->start(...$params);
+                    $params = self::resolveNamedParameters($workflow, 'execute', $request->all()); // no coverage
+                    WorkflowStub::make($workflow)->start(...$params); // no coverage
                     return response()->json([
-                        'message' => 'Workflow started',
-                    ]);
+                        // no coverage
+                        'message' => 'Workflow started', // no coverage
+                    ]); // no coverage
                 });
             }
         }
@@ -101,23 +103,25 @@ class Webhooks
                 Route::post(
                     "{$basePath}/signal/{$slug}/{workflowId}/{$signal}",
                     static function (Request $request, $workflowId) use ($workflow, $method) {
-                        if (! self::validateAuth($request)) {
+                        if (! self::validateAuth($request)) { // no coverage
                             return response()->json([
-                                'error' => 'Unauthorized',
-                            ], 401);
-                        }
+                                // no coverage
+                                'error' => 'Unauthorized', // no coverage
+                            ], 401); // no coverage
+                        } // no coverage
 
-                        $workflowInstance = WorkflowStub::load($workflowId);
-                        $params = self::resolveNamedParameters(
-                            $workflow,
-                            $method->getName(),
-                            $request->except('workflow_id')
-                        );
-                        $workflowInstance->{$method->getName()}(...$params);
+                        $workflowInstance = WorkflowStub::load($workflowId); // no coverage
+                        $params = self::resolveNamedParameters( // no coverage
+                            $workflow, // no coverage
+                            $method->getName(), // no coverage
+                            $request->except('workflow_id') // no coverage
+                        ); // no coverage
+                        $workflowInstance->{$method->getName()}(...$params); // no coverage
 
                         return response()->json([
-                            'message' => 'Signal sent',
-                        ]);
+                            // no coverage
+                            'message' => 'Signal sent', // no coverage
+                        ]); // no coverage
                     }
                 );
             }
@@ -181,6 +185,6 @@ class Webhooks
             return $request->header($header) === $token;
         }
 
-        return false;
+        return false; // no coverage
     }
 }

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -21,6 +21,22 @@ return [
 
     'prune_age' => '1 month',
 
+    'webhooks_route' => env('WORKFLOW_WEBHOOKS_ROUTE', 'webhooks'),
+
+    'webhook_auth' => [
+        'method' => env('WORKFLOW_WEBHOOKS_AUTH_METHOD', 'none'),
+
+        'signature' => [
+            'header' => env('WORKFLOW_WEBHOOKS_SIGNATURE_HEADER', 'X-Signature'),
+            'secret' => env('WORKFLOW_WEBHOOKS_SECRET'),
+        ],
+
+        'token' => [
+            'header' => env('WORKFLOW_WEBHOOKS_TOKEN_HEADER', 'Authorization'),
+            'token' => env('WORKFLOW_WEBHOOKS_TOKEN'),
+        ],
+    ],
+
     'monitor' => env('WORKFLOW_MONITOR', false),
 
     'monitor_url' => env('WORKFLOW_MONITOR_URL'),

--- a/tests/Feature/WebhookWorkflowTest.php
+++ b/tests/Feature/WebhookWorkflowTest.php
@@ -54,7 +54,7 @@ final class WebhookWorkflowTest extends TestCase
             ->toArray());
     }
 
-    public function testSingal(): void
+    public function testSignal(): void
     {
         $this->postJson('/webhooks/start/test-webhook-workflow');
 

--- a/tests/Feature/WebhookWorkflowTest.php
+++ b/tests/Feature/WebhookWorkflowTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\TestOtherActivity;
+use Tests\TestCase;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Signal;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\Webhooks;
+use Workflow\WorkflowStub;
+
+final class WebhookWorkflowTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'workflows.webhook_auth.method' => 'none',
+        ]);
+
+        Webhooks::routes('Tests\\Fixtures', __DIR__ . '/../Fixtures');
+    }
+
+    public function testStart(): void
+    {
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow');
+
+        $this->assertSame(1, StoredWorkflow::count());
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Workflow started',
+        ]);
+
+        $workflow = WorkflowStub::load(1);
+
+        $workflow->cancel();
+
+        while (! $workflow->isCanceled());
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestActivity::class, TestOtherActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+
+    public function testSingal(): void
+    {
+        $this->postJson('/webhooks/start/test-webhook-workflow');
+
+        $this->assertSame(1, StoredWorkflow::count());
+
+        $response = $this->postJson('/webhooks/signal/test-webhook-workflow/1/cancel');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Signal sent',
+        ]);
+
+        $workflow = WorkflowStub::load(1);
+
+        while (! $workflow->isCanceled());
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestActivity::class, TestOtherActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+
+    public function testNotFound(): void
+    {
+        config([
+            'workflows.webhook_auth.method' => 'none',
+        ]);
+
+        $response = $this->postJson('/webhooks/start/does-not-exist');
+
+        $response->assertStatus(404);
+    }
+
+    public function testSignatureAuth()
+    {
+        $secret = 'test-secret';
+        $header = 'X-Signature';
+
+        config([
+            'workflows.webhook_auth.method' => 'signature',
+            'workflows.webhook_auth.signature.secret' => $secret,
+            'workflows.webhook_auth.signature.header' => $header,
+        ]);
+
+        $payload = json_encode([]);
+        $validSignature = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow');
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized',
+        ]);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow', [], [
+            $header => 'invalid-signature',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized',
+        ]);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow', [], [
+            $header => $validSignature,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Workflow started',
+        ]);
+
+        $this->assertSame(1, StoredWorkflow::count());
+
+        $workflow = WorkflowStub::load(1);
+
+        $workflow->cancel();
+
+        while (! $workflow->isCanceled());
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestActivity::class, TestOtherActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+
+    public function testTokenAuth()
+    {
+        $token = 'valid-token';
+        $header = 'Authorization';
+
+        config([
+            'workflows.webhook_auth.method' => 'token',
+            'workflows.webhook_auth.token.token' => $token,
+            'workflows.webhook_auth.token.header' => $header,
+        ]);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow');
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized',
+        ]);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow', [], [
+            $header => 'invalid-token',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized',
+        ]);
+
+        $response = $this->postJson('/webhooks/start/test-webhook-workflow', [], [
+            $header => $token,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Workflow started',
+        ]);
+
+        $this->assertSame(1, StoredWorkflow::count());
+
+        $workflow = WorkflowStub::load(1);
+
+        $workflow->cancel();
+
+        while (! $workflow->isCanceled());
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('workflow_activity_other', $workflow->output());
+        $this->assertSame([TestActivity::class, TestOtherActivity::class, Signal::class], $workflow->logs()
+            ->pluck('class')
+            ->sort()
+            ->values()
+            ->toArray());
+    }
+}

--- a/tests/Fixtures/TestWebhookWorkflow.php
+++ b/tests/Fixtures/TestWebhookWorkflow.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Illuminate\Contracts\Foundation\Application;
+use Workflow\ActivityStub;
+use Workflow\QueryMethod;
+use Workflow\SignalMethod;
+use Workflow\Webhook;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+#[Webhook]
+class TestWebhookWorkflow extends Workflow
+{
+    public $connection = 'redis';
+
+    public $queue = 'default';
+
+    private bool $canceled = false;
+
+    #[SignalMethod]
+    #[Webhook]
+    public function cancel(): void
+    {
+        $this->canceled = true;
+    }
+
+    #[QueryMethod]
+    public function isCanceled(): bool
+    {
+        return $this->canceled;
+    }
+
+    public function execute(Application $app, $shouldAssert = false)
+    {
+        assert($app->runningInConsole());
+
+        if ($shouldAssert) {
+            assert(! $this->canceled);
+        }
+
+        $otherResult = yield ActivityStub::make(TestOtherActivity::class, 'other');
+
+        if ($shouldAssert) {
+            assert(! $this->canceled);
+        }
+
+        yield WorkflowStub::await(fn (): bool => $this->canceled);
+
+        $result = yield ActivityStub::make(TestActivity::class);
+
+        return 'workflow_' . $result . '_' . $otherResult;
+    }
+}

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -102,4 +102,15 @@ final class ActivityTest extends TestCase
         $this->assertSame($workflow->id(), $activity->workflowId());
         $this->assertSame($activity->timeout, pcntl_alarm(0));
     }
+
+    public function testWebhookUrl(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $activity = new TestOtherActivity(0, now()->toDateTimeString(), StoredWorkflow::findOrFail($workflow->id()), [
+            'other',
+        ]);
+
+        $this->assertSame('http://localhost/webhooks/test-workflow', $activity->webhookUrl());
+        $this->assertSame('http://localhost/webhooks/signal/1/other', $activity->webhookUrl('other'));
+    }
 }

--- a/tests/Unit/WebhooksTest.php
+++ b/tests/Unit/WebhooksTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\Http\Request;
+use Mockery;
+use ReflectionClass;
+use ReflectionMethod;
+use Tests\TestCase;
+use Workflow\Webhook;
+use Workflow\Webhooks;
+
+final class WebhooksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Webhooks::routes('Tests\\Fixtures', __DIR__ . '/../Fixtures');
+    }
+
+    public function testScanDirectoryFindsPhpFiles()
+    {
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('scanDirectory');
+        $method->setAccessible(true);
+
+        $files = $method->invoke(null, __DIR__ . '/../Fixtures');
+
+        $this->assertIsArray($files);
+        $this->assertTrue(count($files) > 0);
+    }
+
+    public function testGetClassFromFile()
+    {
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('getClassFromFile');
+        $method->setAccessible(true);
+
+        $namespace = 'Tests\\Fixtures';
+        $basePath = __DIR__ . '/../Fixtures';
+        $filePath = __DIR__ . '/../Fixtures/TestWorkflow.php';
+
+        $class = $method->invoke(null, $filePath, $namespace, $basePath);
+
+        $this->assertEquals('Tests\\Fixtures\\TestWorkflow', $class);
+    }
+
+    public function testHasWebhookAttributeOnclassReturnsTrue()
+    {
+        $mockMethod = Mockery::mock(ReflectionClass::class);
+        $mockMethod->shouldReceive('getAttributes')
+            ->andReturn([new Webhook()]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('hasWebhookAttributeOnclass');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, $mockMethod));
+    }
+
+    public function testHasWebhookAttributeOnclassReturnsFalse()
+    {
+        $mockMethod = Mockery::mock(ReflectionClass::class);
+        $mockMethod->shouldReceive('getAttributes')
+            ->andReturn([]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('hasWebhookAttributeOnclass');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke(null, $mockMethod));
+    }
+
+    public function testHasWebhookAttributeOnMethodReturnsTrue()
+    {
+        $mockMethod = Mockery::mock(ReflectionMethod::class);
+        $mockMethod->shouldReceive('getAttributes')
+            ->andReturn([new Webhook()]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('hasWebhookAttributeOnMethod');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, $mockMethod));
+    }
+
+    public function testHasWebhookAttributeOnMethodReturnsFalse()
+    {
+        $mockMethod = Mockery::mock(ReflectionMethod::class);
+        $mockMethod->shouldReceive('getAttributes')
+            ->andReturn([]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('hasWebhookAttributeOnMethod');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke(null, $mockMethod));
+    }
+
+    public function testValidatesAuthForNone()
+    {
+        config([
+            'workflows.webhook_auth.method' => 'none',
+        ]);
+
+        $request = Request::create('/webhooks/start/test-webhook-workflow', 'POST');
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('validateAuth');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, $request));
+    }
+
+    public function testValidatesAuthForTokenSuccess()
+    {
+        config([
+            'workflows.webhook_auth.method' => 'token',
+            'workflows.webhook_auth.token.token' => 'valid-token',
+            'workflows.webhook_auth.token.header' => 'Authorization',
+        ]);
+
+        $request = Request::create('/webhooks/start/test-webhook-workflow', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'valid-token',
+        ]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('validateAuth');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, $request));
+    }
+
+    public function testValidatesAuthForTokenFailure()
+    {
+        config([
+            'workflows.webhook_auth.method' => 'token',
+            'workflows.webhook_auth.token.token' => 'valid-token',
+            'workflows.webhook_auth.token.header' => 'Authorization',
+        ]);
+
+        $request = Request::create('/webhooks/start/test-webhook-workflow', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'invalid-token',
+        ]);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('validateAuth');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke(null, $request));
+    }
+
+    public function testValidatesAuthForSignatureSuccess()
+    {
+        config([
+            'workflows.webhook_auth.method' => 'signature',
+            'workflows.webhook_auth.signature.secret' => 'test-secret',
+            'workflows.webhook_auth.signature.header' => 'X-Signature',
+        ]);
+
+        $payload = json_encode([
+            'data' => 'test',
+        ]);
+        $signature = hash_hmac('sha256', $payload, 'test-secret');
+
+        $request = Request::create('/webhooks/start/test-webhook-workflow', 'POST', [], [], [], [
+            'HTTP_X_SIGNATURE' => $signature,
+        ], $payload);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('validateAuth');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, $request));
+    }
+
+    public function testValidatesAuthForSignatureFailure()
+    {
+        config([
+            'workflows.webhook_auth.method' => 'signature',
+            'workflows.webhook_auth.signature.secret' => 'test-secret',
+            'workflows.webhook_auth.signature.header' => 'X-Signature',
+        ]);
+
+        $payload = json_encode([
+            'data' => 'test',
+        ]);
+        $invalidSignature = 'invalid-signature';
+
+        $request = Request::create('/webhooks/start/test-webhook-workflow', 'POST', [], [], [], [
+            'HTTP_X_SIGNATURE' => $invalidSignature,
+        ], $payload);
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('validateAuth');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke(null, $request));
+    }
+
+    public function testResolveNamedParameters()
+    {
+        $payload = [
+            'param1' => 'value1',
+            'param2' => 'value2',
+        ];
+
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('resolveNamedParameters');
+        $method->setAccessible(true);
+
+        $params = $method->invoke(null, TestClass::class, 'testMethod', $payload);
+
+        $this->assertSame([
+            'param1' => 'value1',
+            'param2' => 'value2',
+        ], $params);
+    }
+}
+
+class TestClass
+{
+    public function testMethod($param1, $param2)
+    {
+    }
+}

--- a/tests/Unit/WebhooksTest.php
+++ b/tests/Unit/WebhooksTest.php
@@ -35,6 +35,18 @@ final class WebhooksTest extends TestCase
         $this->assertTrue(count($files) > 0);
     }
 
+    public function testDiscoverWorkflowsNotAFolder()
+    {
+        $webhooksReflection = new ReflectionClass(Webhooks::class);
+        $method = $webhooksReflection->getMethod('discoverWorkflows');
+        $method->setAccessible(true);
+
+        $files = $method->invoke(null, 'does-not-exist');
+
+        $this->assertIsArray($files);
+        $this->assertTrue(count($files) === 0);
+    }
+
     public function testGetClassFromFile()
     {
         $webhooksReflection = new ReflectionClass(Webhooks::class);


### PR DESCRIPTION
# Webhooks

Laravel Workflow provides webhooks that allow external systems to start workflows and send signals dynamically. This feature enables seamless integration with external services, APIs, and automation tools.

## Enabling Webhooks
To enable webhooks in Laravel Workflow, register the webhook routes in your application’s routes file (`routes/web.php` or `routes/api.php`):

```php
use Workflow\Webhooks;

Webhooks::routes();
```

By default, webhooks will:
- Auto-discover workflows in the `app/Workflows` folder.
- Expose webhooks to workflows marked with `#[Webhook]` at the class level.
- Expose webhooks to signal methods marked with `#[Webhook]`.

## Starting a Workflow via Webhook
To expose a workflow as a webhook, add the `#[Webhook]` attribute on the class itself.

```php
use Workflow\Webhook;
use Workflow\Workflow;

#[Webhook]
class OrderWorkflow extends Workflow
{
    public function execute($orderId)
    {
        // your code here
    }
}
```

### Webhook URL
```
POST /webhooks/start/order-workflow
```

### Example Request
```bash
curl -X POST "https://example.com/webhooks/start/order-workflow" \
     -H "Content-Type: application/json" \
     -d '{"orderId": 123}'
```

## Sending a Signal via Webhook
To allow external systems to send signals to a workflow, add the `#[Webhook]` attribute on the method.

```php
use Workflow\SignalMethod;
use Workflow\Webhook;
use Workflow\Workflow;

class OrderWorkflow extends Workflow
{
    protected bool $shipped = false;

    #[SignalMethod]
    #[Webhook]
    public function markAsShipped()
    {
        $this->shipped = true;
    }
}
```

### Webhook URL
```
POST /webhooks/signal/order-workflow/{workflowId}/mark-as-shipped
```

### Example Request
```bash
curl -X POST "https://example.com/webhooks/signal/order-workflow/1/mark-as-shipped" \
     -H "Content-Type: application/json"
```

## Webhook URL Helper
The `$this->webhookUrl()` helper generates webhook URLs for starting workflows or sending signals.

```
$activity->webhookUrl();
$activity->webhookUrl('signalMethod');
```

Parameters
- string $signalMethod = '' (optional)

If empty, returns the URL for starting the workflow.

If provided, returns the URL for sending a signal to an active workflow instance.

```
use Workflow\Activity;

class ShipOrderActivity extends Activity
{
    public function execute(string $email, StoredWorkflow $storedWorkflow): void
    {
        $startUrl = $this->webhookUrl();
        // $startUrl = '/webhooks/start/order-workflow';

        $signalUrl = $this->webhookUrl('markAsShipped');
        // $signalUrl = '/webhooks/signal/order-workflow/{workflowId}/mark-as-shipped';
    }
}
```

## Webhook Authentication
By default, webhooks don't require authentication but this can be configured in `config/workflows.php`.

### Authentication Methods
Laravel Workflow supports:
1. No Authentication (none)
2. Token-based Authentication (token)
3. HMAC Signature Verification (signature)

### Token Authentication
For token authentication, webhooks require a valid API token in the request headers. The default header is `Authorization` but you can change this in the configuration settings.

#### Example Request
```bash
curl -X POST "https://example.com/webhooks/start/order-workflow" \
     -H "Content-Type: application/json" \
     -H "Authorization: your-api-token" \
     -d '{"orderId": 123}'
```

### HMAC Signature Authentication
For HMAC authentication, Laravel Workflow verifies requests using a secret key. The default header is `X-Signature` but this can also be changed.

#### Example Request
```bash
BODY='{"orderId": 123}'
SIGNATURE=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "your-secret-key" | awk '{print $2}')

curl -X POST "https://example.com/webhooks/start/order-workflow" \
     -H "Content-Type: application/json" \
     -H "X-Signature: $SIGNATURE" \
     -d "$BODY"
```

## Configuring Webhook Routes
By default, webhooks are accessible under `/webhooks`. You can customize the route path in `config/workflows.php`:

```php
'webhooks_route' => 'api/webhooks',
```