### PR TITLE
Fix exception message

### DIFF
--- a/tests/Fixtures/StateMachine.php
+++ b/tests/Fixtures/StateMachine.php
@@ -44,7 +44,7 @@ class StateMachine
         if (isset($this->transitions[$action]) && $this->transitions[$action]['from'] === $this->currentState) {
             $this->currentState = $this->transitions[$action]['to'];
         } else {
-            throw new Exception('Transition not found,');
+            throw new Exception('Transition not found.');
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix punctuation in `tests/Fixtures/StateMachine.php`

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3e920e188327a089b9ecd4a9b655