### PR TITLE
Exclude workflowId

### DIFF
--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -104,7 +104,7 @@ class Webhooks
                         $params = self::resolveNamedParameters(
                             $workflow,
                             $method->getName(),
-                            $request->except('workflow_id')
+                            $request->except('workflowId')
                         );
                         $workflowInstance->{$method->getName()}(...$params);
                         return response()->json([


### PR DESCRIPTION
## Summary
- exclude `workflowId` when resolving parameters for signal webhooks

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f410c94a083278c5596df132ba581