### PR TITLE
Update token comparison

### DIFF
--- a/src/Auth/SignatureAuthenticator.php
+++ b/src/Auth/SignatureAuthenticator.php
@@ -11,8 +11,8 @@ class SignatureAuthenticator implements WebhookAuthenticator
     public function validate(Request $request): Request
     {
         if (! hash_equals(
-            $request->header(config('workflows.webhook_auth.signature.header')) ?? '',
-            hash_hmac('sha256', $request->getContent(), config('workflows.webhook_auth.signature.secret'))
+            (string) $request->header(config('workflows.webhook_auth.signature.header')),
+            (string) hash_hmac('sha256', $request->getContent(), config('workflows.webhook_auth.signature.secret'))
         )) {
             abort(401, 'Unauthorized');
         }

--- a/src/Auth/TokenAuthenticator.php
+++ b/src/Auth/TokenAuthenticator.php
@@ -10,8 +10,9 @@ class TokenAuthenticator implements WebhookAuthenticator
 {
     public function validate(Request $request): Request
     {
-        if ($request->header(config('workflows.webhook_auth.token.header')) !== config(
-            'workflows.webhook_auth.token.token'
+        if (! hash_equals(
+            (string) config('workflows.webhook_auth.token.token'),
+            (string) $request->header(config('workflows.webhook_auth.token.header'))
         )) {
             abort(401, 'Unauthorized');
         }


### PR DESCRIPTION
## Summary
- secure token comparison via `hash_equals`
- cast to string for signature token comparison

## Testing
- `vendor/bin/phpunit --filter TokenAuth`

------
https://chatgpt.com/codex/tasks/task_e_685da6ece18c8327bb91bb9507160ee2