### PR TITLE
Remove queue:failed-table call from TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,8 +57,6 @@ abstract class TestCase extends BaseTestCase
             '--realpath' => true,
         ]);
 
-        $this->artisan('queue:failed-table');
-
         $this->loadLaravelMigrations();
     }
 


### PR DESCRIPTION
Removed the call to 'queue:failed-table' from the test case.