### PR TITLE
Fix webhook URL generation to include workflow slug

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -77,12 +77,14 @@ class Activity implements ShouldBeEncrypted, ShouldQueue
     public function webhookUrl(string $signalMethod = ''): string
     {
         $basePath = config('workflows.webhooks_route', '/webhooks');
+        $workflow = Str::kebab(class_basename($this->storedWorkflow->class));
+
         if ($signalMethod === '') {
-            $workflow = Str::kebab(class_basename($this->storedWorkflow->class));
             return url("{$basePath}/{$workflow}");
         }
+
         $signal = Str::kebab($signalMethod);
-        return url("{$basePath}/signal/{$this->storedWorkflow->id}/{$signal}");
+        return url("{$basePath}/signal/{$workflow}/{$this->storedWorkflow->id}/{$signal}");
     }
 
     public function handle()

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -131,6 +131,6 @@ final class ActivityTest extends TestCase
         ]);
 
         $this->assertSame('http://localhost/webhooks/test-workflow', $activity->webhookUrl());
-        $this->assertSame('http://localhost/webhooks/signal/1/other', $activity->webhookUrl('other'));
+        $this->assertSame('http://localhost/webhooks/signal/test-workflow/1/other', $activity->webhookUrl('other'));
     }
 }


### PR DESCRIPTION
The Activity::webhookUrl() method was generating URLs that didn't match the route pattern registered by Webhooks::registerSignalWebhooks(), causing 404 errors when external services called the webhooks.

- Added workflow slug to signal webhook URL generation
- Updated test to expect the correct URL format with workflow slug

Resolves issue where signal webhooks were failing due to URL mismatch.

Fixes #269