### PR TITLE
fix: Define $key property because dynamic properties are deprecated

### DIFF
--- a/src/ChildWorkflow.php
+++ b/src/ChildWorkflow.php
@@ -20,6 +20,8 @@ final class ChildWorkflow implements ShouldBeEncrypted, ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    public ?string $key = null;
+
     public $tries = PHP_INT_MAX;
 
     public $maxExceptions = PHP_INT_MAX;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -20,6 +20,8 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    public ?string $key = null;
+
     public $tries = PHP_INT_MAX;
 
     public $maxExceptions = PHP_INT_MAX;

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -38,6 +38,8 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
     use Sagas;
     use SerializesModels;
 
+    public ?string $key = null;
+
     public int $tries = 0;
 
     public int $maxExceptions = 0;


### PR DESCRIPTION
Based on https://github.com/laravel-workflow/laravel-workflow/issues/280, this should fix the warning caused by the creation of the dynamic property $key on the `Workflow`, `ChildWorkflow`, and `Exception` classes through the `WithoutOverlappingMiddleware` middleware.