### PR TITLE
Add Workflow Versioning Support

### DIFF
--- a/src/Exceptions/VersionNotSupportedException.php
+++ b/src/Exceptions/VersionNotSupportedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Exceptions;
+
+use RuntimeException;
+
+class VersionNotSupportedException extends RuntimeException
+{
+}

--- a/src/Traits/Versions.php
+++ b/src/Traits/Versions.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Traits;
+
+use Illuminate\Database\QueryException;
+use React\Promise\PromiseInterface;
+use function React\Promise\resolve;
+use Workflow\Exceptions\VersionNotSupportedException;
+use Workflow\Serializers\Serializer;
+
+trait Versions
+{
+    public static function getVersion(
+        string $changeId,
+        int $minSupported = self::DEFAULT_VERSION,
+        int $maxSupported = 1
+    ): PromiseInterface {
+        $log = self::$context->storedWorkflow->logs()
+            ->whereIndex(self::$context->index)
+            ->first();
+
+        if ($log) {
+            $version = Serializer::unserialize($log->result);
+
+            if ($version < $minSupported || $version > $maxSupported) {
+                throw new VersionNotSupportedException(
+                    "Version {$version} for change ID '{$changeId}' is not supported. " .
+                    "Supported range: [{$minSupported}, {$maxSupported}]"
+                );
+            }
+
+            ++self::$context->index;
+            return resolve($version);
+        }
+
+        $version = $maxSupported;
+
+        if (! self::$context->replaying) {
+            try {
+                self::$context->storedWorkflow->logs()
+                    ->create([
+                        'index' => self::$context->index,
+                        'now' => self::$context->now,
+                        'class' => 'version:' . $changeId,
+                        'result' => Serializer::serialize($version),
+                    ]);
+            } catch (QueryException $exception) {
+                $log = self::$context->storedWorkflow->logs()
+                    ->whereIndex(self::$context->index)
+                    ->first();
+
+                if ($log) {
+                    $version = Serializer::unserialize($log->result);
+
+                    if ($version < $minSupported || $version > $maxSupported) {
+                        throw new VersionNotSupportedException(
+                            "Version {$version} for change ID '{$changeId}' is not supported. " .
+                            "Supported range: [{$minSupported}, {$maxSupported}]"
+                        );
+                    }
+
+                    ++self::$context->index;
+                    return resolve($version);
+                }
+
+                throw $exception;
+            }
+        }
+
+        ++self::$context->index;
+        return resolve($version);
+    }
+}

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -24,6 +24,7 @@ use Workflow\Traits\Continues;
 use Workflow\Traits\Fakes;
 use Workflow\Traits\SideEffects;
 use Workflow\Traits\Timers;
+use Workflow\Traits\Versions;
 
 final class WorkflowStub
 {
@@ -34,6 +35,9 @@ final class WorkflowStub
     use Macroable;
     use SideEffects;
     use Timers;
+    use Versions;
+
+    public const DEFAULT_VERSION = -1;
 
     private static ?\stdClass $context = null;
 

--- a/tests/Feature/VersionWorkflowTest.php
+++ b/tests/Feature/VersionWorkflowTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestVersionedActivityV3;
+use Tests\Fixtures\TestVersionMinSupportedWorkflow;
+use Tests\Fixtures\TestVersionWorkflow;
+use Tests\TestCase;
+use Workflow\Exceptions\VersionNotSupportedException;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Serializer;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\States\WorkflowFailedStatus;
+use Workflow\WorkflowStub;
+
+final class VersionWorkflowTest extends TestCase
+{
+    public function testNewWorkflowUsesMaxVersion(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+
+        $output = $workflow->output();
+        $this->assertSame(2, $output['version1']);
+        $this->assertSame('v3_result', $output['result1']);
+        $this->assertSame(1, $output['version2']);
+        $this->assertSame('new_path', $output['result2']);
+    }
+
+    public function testVersionIsRecordedInLogs(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $logs = $workflow->logs()
+            ->pluck('class')
+            ->toArray();
+
+        $this->assertContains('version:step-1', $logs);
+        $this->assertContains('version:step-2', $logs);
+        $this->assertContains(TestVersionedActivityV3::class, $logs);
+    }
+
+    public function testVersionIsReplayedFromLogs(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now(),
+                'class' => 'version:step-1',
+                'result' => Serializer::serialize(1),
+            ]);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+
+        $output = $workflow->output();
+
+        $this->assertSame(1, $output['version1']);
+        $this->assertSame('v2_result', $output['result1']);
+    }
+
+    public function testDefaultVersionIsReplayedFromLogs(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now(),
+                'class' => 'version:step-1',
+                'result' => Serializer::serialize(WorkflowStub::DEFAULT_VERSION),
+            ]);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+
+        $output = $workflow->output();
+
+        $this->assertSame(WorkflowStub::DEFAULT_VERSION, $output['version1']);
+        $this->assertSame('v1_result', $output['result1']);
+    }
+
+    public function testVersionBelowMinSupportedThrowsException(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionMinSupportedWorkflow::class);
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now(),
+                'class' => 'version:step-1',
+                'result' => Serializer::serialize(WorkflowStub::DEFAULT_VERSION),
+            ]);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
+        $this->assertNotNull($workflow->exceptions()->first());
+
+        $exception = Serializer::unserialize($workflow->exceptions()->first()->exception);
+        $this->assertSame(VersionNotSupportedException::class, $exception['class']);
+        $this->assertStringContainsString("Version -1 for change ID 'step-1' is not supported", $exception['message']);
+    }
+
+    public function testVersionAboveMaxSupportedThrowsException(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now(),
+                'class' => 'version:step-1',
+                'result' => Serializer::serialize(99),
+            ]);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowFailedStatus::class, $workflow->status());
+        $this->assertNotNull($workflow->exceptions()->first());
+
+        $exception = Serializer::unserialize($workflow->exceptions()->first()->exception);
+        $this->assertSame(VersionNotSupportedException::class, $exception['class']);
+        $this->assertStringContainsString("Version 99 for change ID 'step-1' is not supported", $exception['message']);
+    }
+
+    public function testMultipleVersionChangePoints(): void
+    {
+        $workflow = WorkflowStub::make(TestVersionWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+
+        $versionLogs = $workflow->logs()
+            ->filter(static fn ($log) => str_starts_with($log->class, 'version:'))
+            ->values();
+
+        $this->assertCount(2, $versionLogs);
+        $this->assertSame('version:step-1', $versionLogs[0]->class);
+        $this->assertSame('version:step-2', $versionLogs[1]->class);
+    }
+}

--- a/tests/Fixtures/TestVersionMinSupportedWorkflow.php
+++ b/tests/Fixtures/TestVersionMinSupportedWorkflow.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class TestVersionMinSupportedWorkflow extends Workflow
+{
+    public $connection = 'redis';
+
+    public $queue = 'default';
+
+    public function execute()
+    {
+        // minSupported is 1, so DEFAULT_VERSION (-1) is no longer supported
+        $version = yield WorkflowStub::getVersion(
+            'step-1',
+            1,  // minSupported: we dropped support for DEFAULT_VERSION
+            2   // maxSupported: current version
+        );
+
+        $result = match ($version) {
+            1 => yield ActivityStub::make(TestVersionedActivityV2::class),
+            2 => yield ActivityStub::make(TestVersionedActivityV3::class),
+        };
+
+        return [
+            'version' => $version,
+            'result' => $result,
+        ];
+    }
+}

--- a/tests/Fixtures/TestVersionWorkflow.php
+++ b/tests/Fixtures/TestVersionWorkflow.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\ActivityStub;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+class TestVersionWorkflow extends Workflow
+{
+    public $connection = 'redis';
+
+    public $queue = 'default';
+
+    public function execute()
+    {
+        $version = yield WorkflowStub::getVersion('step-1', WorkflowStub::DEFAULT_VERSION, 2);
+
+        $result = match ($version) {
+            WorkflowStub::DEFAULT_VERSION => yield ActivityStub::make(TestVersionedActivityV1::class),
+            1 => yield ActivityStub::make(TestVersionedActivityV2::class),
+            2 => yield ActivityStub::make(TestVersionedActivityV3::class),
+        };
+
+        $version2 = yield WorkflowStub::getVersion('step-2', WorkflowStub::DEFAULT_VERSION, 1);
+
+        $result2 = $version2 === WorkflowStub::DEFAULT_VERSION
+            ? 'old_path'
+            : 'new_path';
+
+        return [
+            'version1' => $version,
+            'result1' => $result,
+            'version2' => $version2,
+            'result2' => $result2,
+        ];
+    }
+}

--- a/tests/Fixtures/TestVersionedActivityV1.php
+++ b/tests/Fixtures/TestVersionedActivityV1.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestVersionedActivityV1 extends Activity
+{
+    public function execute(): string
+    {
+        return 'v1_result';
+    }
+}

--- a/tests/Fixtures/TestVersionedActivityV2.php
+++ b/tests/Fixtures/TestVersionedActivityV2.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestVersionedActivityV2 extends Activity
+{
+    public function execute(): string
+    {
+        return 'v2_result';
+    }
+}

--- a/tests/Fixtures/TestVersionedActivityV3.php
+++ b/tests/Fixtures/TestVersionedActivityV3.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestVersionedActivityV3 extends Activity
+{
+    public function execute(): string
+    {
+        return 'v3_result';
+    }
+}

--- a/tests/Unit/Traits/VersionsTest.php
+++ b/tests/Unit/Traits/VersionsTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Traits;
+
+use Mockery;
+use Tests\Fixtures\TestWorkflow;
+use Tests\TestCase;
+use Workflow\Exceptions\VersionNotSupportedException;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Serializer;
+use Workflow\WorkflowStub;
+
+final class VersionsTest extends TestCase
+{
+    public function testStoresResult(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1)
+            ->then(static function ($value) use (&$result): void {
+                $result = $value;
+            });
+
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $workflow->logs()->count());
+        $this->assertDatabaseHas('workflow_logs', [
+            'stored_workflow_id' => $workflow->id(),
+            'index' => 0,
+            'class' => 'version:test-change',
+        ]);
+        $this->assertSame(1, Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
+    }
+
+    public function testLoadsStoredResult(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => 'version:test-change',
+                'result' => Serializer::serialize(WorkflowStub::DEFAULT_VERSION),
+            ]);
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1)
+            ->then(static function ($value) use (&$result): void {
+                $result = $value;
+            });
+
+        $this->assertSame(WorkflowStub::DEFAULT_VERSION, $result);
+        $this->assertSame(1, $workflow->logs()->count());
+    }
+
+    public function testThrowsExceptionWhenVersionBelowMinSupported(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => 'version:test-change',
+                'result' => Serializer::serialize(WorkflowStub::DEFAULT_VERSION),
+            ]);
+
+        $this->expectException(VersionNotSupportedException::class);
+        $this->expectExceptionMessage(
+            "Version -1 for change ID 'test-change' is not supported. Supported range: [1, 2]"
+        );
+
+        WorkflowStub::getVersion('test-change', 1, 2);
+    }
+
+    public function testThrowsExceptionWhenVersionAboveMaxSupported(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => 'version:test-change',
+                'result' => Serializer::serialize(99),
+            ]);
+
+        $this->expectException(VersionNotSupportedException::class);
+        $this->expectExceptionMessage(
+            "Version 99 for change ID 'test-change' is not supported. Supported range: [-1, 2]"
+        );
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 2);
+    }
+
+    public function testResolvesConflictingResult(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => StoredWorkflow::findOrFail($workflow->id()),
+            'index' => 0,
+            'now' => now(),
+            'replaying' => false,
+        ]);
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1)
+            ->then(static function ($value) use (&$result): void {
+                $result = $value;
+            });
+
+        $this->assertSame(1, $result);
+        $this->assertSame(1, $workflow->logs()->count());
+    }
+
+    public function testResolvesConflictingResultWithValidVersion(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $mockLogs = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class)
+            ->shouldReceive('whereIndex')
+            ->andReturnSelf()
+            ->shouldReceive('first')
+            ->once()
+            ->andReturn(null)
+            ->shouldReceive('create')
+            ->andThrow(new \Illuminate\Database\QueryException('', '', [], new \Exception('Duplicate entry')))
+            ->shouldReceive('first')
+            ->once()
+            ->andReturn((object) [
+                'result' => Serializer::serialize(1),
+            ])
+            ->getMock();
+
+        $mockStoredWorkflow = Mockery::spy($storedWorkflow);
+
+        $mockStoredWorkflow->shouldReceive('logs')
+            ->andReturnUsing(static function () use ($mockLogs) {
+                return $mockLogs;
+            });
+
+        $mockStoredWorkflow->class = TestWorkflow::class;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $mockStoredWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => false,
+        ]);
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 2)
+            ->then(static function ($value) use (&$result): void {
+                $result = $value;
+            });
+
+        $this->assertSame(1, $result);
+
+        Mockery::close();
+    }
+
+    public function testResolvesConflictingResultThrowsWhenVersionNotSupported(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $mockLogs = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class)
+            ->shouldReceive('whereIndex')
+            ->andReturnSelf()
+            ->shouldReceive('first')
+            ->once()
+            ->andReturn(null)
+            ->shouldReceive('create')
+            ->andThrow(new \Illuminate\Database\QueryException('', '', [], new \Exception('Duplicate entry')))
+            ->shouldReceive('first')
+            ->once()
+            ->andReturn((object) [
+                'result' => Serializer::serialize(99),
+            ])
+            ->getMock();
+
+        $mockStoredWorkflow = Mockery::spy($storedWorkflow);
+
+        $mockStoredWorkflow->shouldReceive('logs')
+            ->andReturnUsing(static function () use ($mockLogs) {
+                return $mockLogs;
+            });
+
+        $mockStoredWorkflow->class = TestWorkflow::class;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $mockStoredWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => false,
+        ]);
+
+        $this->expectException(VersionNotSupportedException::class);
+        $this->expectExceptionMessage(
+            "Version 99 for change ID 'test-change' is not supported. Supported range: [-1, 2]"
+        );
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 2);
+
+        Mockery::close();
+    }
+
+    public function testThrowsQueryExceptionWhenNotDuplicateKey(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $mockLogs = Mockery::mock(\Illuminate\Database\Eloquent\Relations\HasMany::class)
+            ->shouldReceive('whereIndex')
+            ->twice()
+            ->andReturnSelf()
+            ->shouldReceive('first')
+            ->twice()
+            ->andReturn(null)
+            ->shouldReceive('create')
+            ->andThrow(new \Illuminate\Database\QueryException('', '', [], new \Exception('Some other error')))
+            ->getMock();
+
+        $mockStoredWorkflow = Mockery::spy($storedWorkflow);
+
+        $mockStoredWorkflow->shouldReceive('logs')
+            ->andReturnUsing(static function () use ($mockLogs) {
+                return $mockLogs;
+            });
+
+        $mockStoredWorkflow->class = TestWorkflow::class;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $mockStoredWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => false,
+        ]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1);
+
+        Mockery::close();
+    }
+}


### PR DESCRIPTION
This PR adds versioning support to Laravel Workflow. This allows you to safely make changes to running workflows without causing non-determinism errors during replay.

### Motivation

Since Workflow Executions can run for long periods, sometimes months or even years, it's common to need to make changes to a Workflow Definition while executions are still in progress. Without versioning, modifying workflow code that affects the execution path would cause non-determinism errors during replay.

### Usage

Use `WorkflowStub::getVersion()` to create versioned branch points in your workflow:

```php
use Workflow\Workflow;
use Workflow\WorkflowStub;

class MyWorkflow extends Workflow
{
    public function execute()
    {
        $version = yield WorkflowStub::getVersion(
            'my-change-id',           // Unique identifier for this change
            WorkflowStub::DEFAULT_VERSION,  // Minimum supported version
            1                         // Maximum (current) version
        );

        if ($version === WorkflowStub::DEFAULT_VERSION) {
            // Old code path for workflows started before the change
            yield ActivityStub::make(OldActivity::class);
        } else {
            // New code path for workflows started after the change
            yield ActivityStub::make(NewActivity::class);
        }
    }
}
```

### How It Works

- **New executions**: Records `maxSupported` version as a marker in the workflow logs and returns it
- **Replaying executions**: Returns the previously recorded version from the logs
- **Version validation**: Throws `VersionNotSupportedException` if the recorded version is outside the `[minSupported, maxSupported]` range

### Deprecating Old Versions

After all workflows using an old version have completed, you can drop support:

```php
// After all DEFAULT_VERSION workflows have completed:
$version = yield WorkflowStub::getVersion('my-change-id', 1, 2);

$result = match($version) {
    1 => yield ActivityStub::make(PostPatchActivity::class),
    2 => yield ActivityStub::make(AnotherPatchActivity::class),
};
```