### PR TITLE
Fix timer replay

### DIFF
--- a/src/Traits/AwaitWithTimeouts.php
+++ b/src/Traits/AwaitWithTimeouts.php
@@ -10,6 +10,7 @@ use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Workflow\Serializers\Serializer;
 use Workflow\Signal;
+use Workflow\Timer;
 
 trait AwaitWithTimeouts
 {
@@ -19,7 +20,14 @@ trait AwaitWithTimeouts
 
         if ($log) {
             ++self::$context->index;
-            return resolve(Serializer::unserialize($log->result));
+
+            $result = Serializer::unserialize($log->result);
+
+            if ($log->class === Timer::class) {
+                return resolve(! $result);
+            }
+
+            return resolve($result);
         }
 
         $result = $condition();

--- a/tests/Feature/AwaitWithTimeoutWorkflowTest.php
+++ b/tests/Feature/AwaitWithTimeoutWorkflowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Tests\Fixtures\TestAwaitWithTimeoutReplayWorkflow;
 use Tests\Fixtures\TestAwaitWithTimeoutWorkflow;
 use Tests\TestCase;
 use Workflow\States\WorkflowCompletedStatus;
@@ -39,5 +40,17 @@ final class AwaitWithTimeoutWorkflowTest extends TestCase
         $this->assertGreaterThanOrEqual(5, now()->diffInSeconds($now));
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_timed_out', $workflow->output());
+    }
+
+    public function testTimedoutResultStaysFalseAfterReplay(): void
+    {
+        $workflow = WorkflowStub::make(TestAwaitWithTimeoutReplayWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertFalse($workflow->output());
     }
 }

--- a/tests/Fixtures/TestAwaitWithTimeoutReplayWorkflow.php
+++ b/tests/Fixtures/TestAwaitWithTimeoutReplayWorkflow.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use function Workflow\activity;
+use function Workflow\awaitWithTimeout;
+use Workflow\Workflow;
+
+final class TestAwaitWithTimeoutReplayWorkflow extends Workflow
+{
+    public function execute()
+    {
+        $result = yield awaitWithTimeout(1, static fn (): bool => false);
+
+        yield activity(TestCountActivity::class, $result ? 1 : 0);
+
+        return $result;
+    }
+}

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -135,7 +135,7 @@ final class TimersTest extends TestCase
                 $result = $value;
             });
 
-        $this->assertSame(true, $result);
+        $this->assertSame(false, $result);
         $this->assertSame(1, $workflow->logs()->count());
         $this->assertDatabaseHas('workflow_logs', [
             'stored_workflow_id' => $workflow->id(),


### PR DESCRIPTION
Issue: Timer logs store “timer completed” (true), but awaitWithTimeout returns “condition met before timeout,” which is the inverse. On replay, returning raw timer log values flips false -> true.