### PR TITLE
Stabilize workflow fixture assertions

### DIFF
--- a/tests/Feature/WorkflowTest.php
+++ b/tests/Feature/WorkflowTest.php
@@ -51,11 +51,14 @@ final class WorkflowTest extends TestCase
 
         $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
         $this->assertSame('workflow_activity_other', $workflow->output());
-        $this->assertSame([TestActivity::class, TestOtherActivity::class, Signal::class], $workflow->logs()
-            ->pluck('class')
-            ->sort()
-            ->values()
-            ->toArray());
+        $this->assertSame(
+            [TestActivity::class, TestOtherActivity::class, TestWorkflow::class, Signal::class],
+            $workflow->logs()
+                ->pluck('class')
+                ->sort()
+                ->values()
+                ->toArray()
+        );
     }
 
     public function testTestSignalExceptionWorkflowEarly(): void

--- a/tests/Fixtures/TestActivity.php
+++ b/tests/Fixtures/TestActivity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
 
@@ -11,7 +12,9 @@ class TestActivity extends Activity
 {
     public function execute(Application $app)
     {
-        assert($app->runningInConsole());
+        if (! $app->runningInConsole()) {
+            throw new AssertionError('Test activities must run in console.');
+        }
 
         return 'activity';
     }

--- a/tests/Fixtures/TestAsyncWorkflow.php
+++ b/tests/Fixtures/TestAsyncWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Workflow;
 use function Workflow\{activity, async};
@@ -13,7 +14,9 @@ final class TestAsyncWorkflow extends Workflow
     public function execute()
     {
         $results = yield async(static function (Application $app) {
-            assert($app->runningInConsole());
+            if (! $app->runningInConsole()) {
+                throw new AssertionError('Test workflows must run in console.');
+            }
 
             $otherResult = yield activity(TestOtherActivity::class, 'other');
 

--- a/tests/Fixtures/TestBadConnectionWorkflow.php
+++ b/tests/Fixtures/TestBadConnectionWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\QueryMethod;
 use Workflow\SignalMethod;
@@ -32,16 +33,22 @@ class TestBadConnectionWorkflow extends Workflow
 
     public function execute(Application $app, $shouldAssert = false)
     {
-        assert($app->runningInConsole());
+        if (! $app->runningInConsole()) {
+            throw new AssertionError('Test workflows must run in console.');
+        }
 
         if ($shouldAssert) {
-            assert(yield sideEffect(fn (): bool => ! $this->canceled));
+            if (! (yield sideEffect(fn (): bool => ! $this->canceled))) {
+                throw new AssertionError('Workflow should not be canceled before the first activity.');
+            }
         }
 
         $otherResult = yield activity(TestOtherActivity::class, 'other');
 
         if ($shouldAssert) {
-            assert(yield sideEffect(fn (): bool => ! $this->canceled));
+            if (! (yield sideEffect(fn (): bool => ! $this->canceled))) {
+                throw new AssertionError('Workflow should not be canceled before awaiting the signal.');
+            }
         }
 
         yield await(fn (): bool => $this->canceled);

--- a/tests/Fixtures/TestOtherActivity.php
+++ b/tests/Fixtures/TestOtherActivity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\Activity;
 
@@ -11,7 +12,9 @@ final class TestOtherActivity extends Activity
 {
     public function execute(Application $app, $string)
     {
-        assert($app->runningInConsole());
+        if (! $app->runningInConsole()) {
+            throw new AssertionError('Test activities must run in console.');
+        }
 
         return $string;
     }

--- a/tests/Fixtures/TestWebhookWorkflow.php
+++ b/tests/Fixtures/TestWebhookWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\QueryMethod;
 use Workflow\SignalMethod;
@@ -35,16 +36,22 @@ class TestWebhookWorkflow extends Workflow
 
     public function execute(Application $app, $shouldAssert = false)
     {
-        assert($app->runningInConsole());
+        if (! $app->runningInConsole()) {
+            throw new AssertionError('Test workflows must run in console.');
+        }
 
         if ($shouldAssert) {
-            assert(yield sideEffect(fn (): bool => ! $this->canceled));
+            if (! (yield sideEffect(fn (): bool => ! $this->canceled))) {
+                throw new AssertionError('Workflow should not be canceled before the first activity.');
+            }
         }
 
         $otherResult = yield activity(TestOtherActivity::class, 'other');
 
         if ($shouldAssert) {
-            assert(yield sideEffect(fn (): bool => ! $this->canceled));
+            if (! (yield sideEffect(fn (): bool => ! $this->canceled))) {
+                throw new AssertionError('Workflow should not be canceled before awaiting the signal.');
+            }
         }
 
         yield await(fn (): bool => $this->canceled);

--- a/tests/Fixtures/TestWorkflow.php
+++ b/tests/Fixtures/TestWorkflow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures;
 
+use AssertionError;
 use Illuminate\Contracts\Foundation\Application;
 use Workflow\QueryMethod;
 use Workflow\SignalMethod;
@@ -35,10 +36,14 @@ class TestWorkflow extends Workflow
 
     public function execute(Application $app, $shouldAssert = false)
     {
-        assert($app->runningInConsole());
+        if (! $app->runningInConsole()) {
+            throw new AssertionError('Test workflows must run in console.');
+        }
 
         if ($shouldAssert) {
-            assert(yield sideEffect(fn (): bool => ! $this->canceled));
+            if (! (yield sideEffect(fn (): bool => ! $this->canceled))) {
+                throw new AssertionError('Workflow should not be canceled before the first activity.');
+            }
         }
 
         $otherResult = yield activity(TestOtherActivity::class, 'other');


### PR DESCRIPTION
## Summary
- replace assertion-driven workflow fixture checks with explicit `AssertionError` guards so test behavior does not depend on PHP `assert` settings
- keep the `runningInConsole()` preconditions explicit in test fixtures instead of letting them disappear when assertions are disabled
- update `WorkflowTest::testCompletedDelay()` to expect the deterministic `TestWorkflow` side-effect log entry

## Testing
- `composer feature -- --filter AsyncWorkflowTest`
- `vendor/bin/phpunit --testdox --testsuite feature --filter '^Tests\\Feature\\WorkflowTest(::.*)?$'`
- `composer unit -- --filter WorkflowStubTest`
