### PR TITLE
Exception logs probe

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -82,6 +82,7 @@ jobs:
         DB_CONNECTION: mysql
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
         QUEUE_CONNECTION: redis
+        WORKFLOW_TEST_STREAM_WORKER_OUTPUT: 1
 
     - name: Run test suite (PostgreSQL)
       run: vendor/bin/phpunit --testdox --debug --testsuite feature
@@ -89,6 +90,7 @@ jobs:
         DB_CONNECTION: pgsql
         DB_PORT: ${{ job.services.postgres.ports[5432] }}
         QUEUE_CONNECTION: redis
+        WORKFLOW_TEST_STREAM_WORKER_OUTPUT: 1
 
     - name: Upload laravel.log if tests fail
       if: failure()

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -82,7 +82,7 @@ jobs:
         DB_CONNECTION: mysql
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
         QUEUE_CONNECTION: redis
-        WORKFLOW_TEST_STREAM_WORKER_OUTPUT: 1
+        WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT: 1
 
     - name: Run test suite (PostgreSQL)
       run: vendor/bin/phpunit --testdox --debug --testsuite feature
@@ -90,14 +90,16 @@ jobs:
         DB_CONNECTION: pgsql
         DB_PORT: ${{ job.services.postgres.ports[5432] }}
         QUEUE_CONNECTION: redis
-        WORKFLOW_TEST_STREAM_WORKER_OUTPUT: 1
+        WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT: 1
 
     - name: Upload laravel.log if tests fail
       if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: laravel-log
-        path: vendor/orchestra/testbench-core/laravel/storage/logs/laravel.log
+        path: |
+          vendor/orchestra/testbench-core/laravel/storage/logs/laravel.log
+          vendor/orchestra/testbench-core/laravel/storage/logs/workflow-test-worker-*.log
 
     - name: Code Coverage
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -82,7 +82,6 @@ jobs:
         DB_CONNECTION: mysql
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
         QUEUE_CONNECTION: redis
-        WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT: 1
 
     - name: Run test suite (PostgreSQL)
       run: vendor/bin/phpunit --testdox --debug --testsuite feature
@@ -90,16 +89,13 @@ jobs:
         DB_CONNECTION: pgsql
         DB_PORT: ${{ job.services.postgres.ports[5432] }}
         QUEUE_CONNECTION: redis
-        WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT: 1
 
     - name: Upload laravel.log if tests fail
       if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: laravel-log
-        path: |
-          vendor/orchestra/testbench-core/laravel/storage/logs/laravel.log
-          vendor/orchestra/testbench-core/laravel/storage/logs/workflow-test-worker-*.log
+        path: vendor/orchestra/testbench-core/laravel/storage/logs/laravel.log
 
     - name: Code Coverage
       run: |

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -170,7 +170,8 @@ class Activity implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
             $this->storedWorkflow,
             $throwable,
             $workflow->connection(),
-            $workflow->queue()
+            $workflow->queue(),
+            $this::class
         );
     }
 

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -89,15 +89,13 @@ final class ActivityStub
         if (WorkflowStub::isProbing()) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            $deferred = new Deferred();
-            return $deferred->promise();
+            return (new Deferred())->promise();
         }
 
         $activity::dispatch($context->index, $context->now, $context->storedWorkflow, ...$arguments);
 
         ++$context->index;
         WorkflowStub::setContext($context);
-        $deferred = new Deferred();
-        return $deferred->promise();
+        return (new Deferred())->promise();
     }
 }

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -64,7 +64,6 @@ final class ActivityStub
             }
 
             ++$context->index;
-            WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
             if (
                 is_array($result) &&
@@ -88,14 +87,12 @@ final class ActivityStub
 
         if (WorkflowStub::isProbing()) {
             ++$context->index;
-            WorkflowStub::setContext($context);
             return (new Deferred())->promise();
         }
 
         $activity::dispatch($context->index, $context->now, $context->storedWorkflow, ...$arguments);
 
         ++$context->index;
-        WorkflowStub::setContext($context);
         return (new Deferred())->promise();
     }
 }

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -38,14 +38,14 @@ final class ActivityStub
                 $mocks = WorkflowStub::mocks();
 
                 if (! $log && array_key_exists($activity, $mocks)) {
-                    $result = $mocks[$activity];
+                    $mockedResult = $mocks[$activity];
 
                     $log = $context->storedWorkflow->createLog([
                         'index' => $context->index,
                         'now' => $context->now,
                         'class' => $activity,
                         'result' => Serializer::serialize(
-                            is_callable($result) ? $result($context, ...$arguments) : $result
+                            is_callable($mockedResult) ? $mockedResult($context, ...$arguments) : $mockedResult
                         ),
                     ]);
 

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -28,9 +28,11 @@ final class ActivityStub
     public static function make($activity, ...$arguments): PromiseInterface
     {
         $context = WorkflowStub::getContext();
+        $result = null;
 
         while (true) {
             $log = $context->storedWorkflow->findLogByIndex($context->index);
+            $result = null;
 
             if (WorkflowStub::faked()) {
                 $mocks = WorkflowStub::mocks();
@@ -51,10 +53,17 @@ final class ActivityStub
                 }
             }
 
-            if (! $log || ! ($log->class === Exception::class && self::isForeignExceptionResult(
-                Serializer::unserialize($log->result),
-                $activity
-            ))) {
+            if (! $log) {
+                break;
+            }
+
+            if ($log->class !== Exception::class) {
+                break;
+            }
+
+            $result = Serializer::unserialize($log->result);
+
+            if (! self::isForeignExceptionResult($result, $activity)) {
                 break;
             }
 
@@ -63,7 +72,7 @@ final class ActivityStub
         }
 
         if ($log) {
-            $result = Serializer::unserialize($log->result);
+            $result ??= Serializer::unserialize($log->result);
 
             if (
                 WorkflowStub::isProbing()

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -51,6 +51,18 @@ final class ActivityStub
         }
 
         if ($log) {
+            if (
+                WorkflowStub::isProbing()
+                && WorkflowStub::probeIndex() === $context->index
+                && (
+                    WorkflowStub::probeClass() === null
+                    || WorkflowStub::probeClass() === $activity
+                )
+                && $log->class === Exception::class
+            ) {
+                WorkflowStub::markProbeMatched();
+            }
+
             ++$context->index;
             WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
@@ -72,6 +84,13 @@ final class ActivityStub
                 throw $throwable;
             }
             return resolve($result);
+        }
+
+        if (WorkflowStub::isProbing()) {
+            ++$context->index;
+            WorkflowStub::setContext($context);
+            $deferred = new Deferred();
+            return $deferred->promise();
         }
 
         $activity::dispatch($context->index, $context->now, $context->storedWorkflow, ...$arguments);

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -51,6 +51,15 @@ final class ActivityStub
         }
 
         if ($log) {
+            $result = Serializer::unserialize($log->result);
+
+            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $activity)) {
+                ++$context->index;
+                WorkflowStub::setContext($context);
+
+                return self::make($activity, ...$arguments);
+            }
+
             if (
                 WorkflowStub::isProbing()
                 && WorkflowStub::probeIndex() === $context->index
@@ -65,10 +74,6 @@ final class ActivityStub
 
             ++$context->index;
             WorkflowStub::setContext($context);
-            $result = Serializer::unserialize($log->result);
-            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $activity)) {
-                return self::make($activity, ...$arguments);
-            }
             if (
                 is_array($result) &&
                 array_key_exists('class', $result) &&

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -66,6 +66,9 @@ final class ActivityStub
             ++$context->index;
             WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
+            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $activity)) {
+                return self::make($activity, ...$arguments);
+            }
             if (
                 is_array($result) &&
                 array_key_exists('class', $result) &&
@@ -97,5 +100,13 @@ final class ActivityStub
         ++$context->index;
         WorkflowStub::setContext($context);
         return (new Deferred())->promise();
+    }
+
+    private static function isForeignExceptionResult(mixed $result, string $activity): bool
+    {
+        return is_array($result)
+            && isset($result['sourceClass'])
+            && is_string($result['sourceClass'])
+            && $result['sourceClass'] !== $activity;
     }
 }

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -95,6 +95,7 @@ final class ActivityStub
         }
 
         if (WorkflowStub::isProbing()) {
+            WorkflowStub::markProbePendingBeforeMatch();
             ++$context->index;
             WorkflowStub::setContext($context);
             return (new Deferred())->promise();

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -64,6 +64,7 @@ final class ActivityStub
             }
 
             ++$context->index;
+            WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
             if (
                 is_array($result) &&
@@ -87,12 +88,14 @@ final class ActivityStub
 
         if (WorkflowStub::isProbing()) {
             ++$context->index;
+            WorkflowStub::setContext($context);
             return (new Deferred())->promise();
         }
 
         $activity::dispatch($context->index, $context->now, $context->storedWorkflow, ...$arguments);
 
         ++$context->index;
+        WorkflowStub::setContext($context);
         return (new Deferred())->promise();
     }
 }

--- a/src/ActivityStub.php
+++ b/src/ActivityStub.php
@@ -29,36 +29,41 @@ final class ActivityStub
     {
         $context = WorkflowStub::getContext();
 
-        $log = $context->storedWorkflow->findLogByIndex($context->index);
+        while (true) {
+            $log = $context->storedWorkflow->findLogByIndex($context->index);
 
-        if (WorkflowStub::faked()) {
-            $mocks = WorkflowStub::mocks();
+            if (WorkflowStub::faked()) {
+                $mocks = WorkflowStub::mocks();
 
-            if (! $log && array_key_exists($activity, $mocks)) {
-                $result = $mocks[$activity];
+                if (! $log && array_key_exists($activity, $mocks)) {
+                    $result = $mocks[$activity];
 
-                $log = $context->storedWorkflow->createLog([
-                    'index' => $context->index,
-                    'now' => $context->now,
-                    'class' => $activity,
-                    'result' => Serializer::serialize(
-                        is_callable($result) ? $result($context, ...$arguments) : $result
-                    ),
-                ]);
+                    $log = $context->storedWorkflow->createLog([
+                        'index' => $context->index,
+                        'now' => $context->now,
+                        'class' => $activity,
+                        'result' => Serializer::serialize(
+                            is_callable($result) ? $result($context, ...$arguments) : $result
+                        ),
+                    ]);
 
-                WorkflowStub::recordDispatched($activity, $arguments);
+                    WorkflowStub::recordDispatched($activity, $arguments);
+                }
             }
+
+            if (! $log || ! ($log->class === Exception::class && self::isForeignExceptionResult(
+                Serializer::unserialize($log->result),
+                $activity
+            ))) {
+                break;
+            }
+
+            ++$context->index;
+            WorkflowStub::setContext($context);
         }
 
         if ($log) {
             $result = Serializer::unserialize($log->result);
-
-            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $activity)) {
-                ++$context->index;
-                WorkflowStub::setContext($context);
-
-                return self::make($activity, ...$arguments);
-            }
 
             if (
                 WorkflowStub::isProbing()

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -45,6 +45,18 @@ final class ChildWorkflowStub
         }
 
         if ($log) {
+            if (
+                WorkflowStub::isProbing()
+                && WorkflowStub::probeIndex() === $context->index
+                && (
+                    WorkflowStub::probeClass() === null
+                    || WorkflowStub::probeClass() === $workflow
+                )
+                && $log->class === Exception::class
+            ) {
+                WorkflowStub::markProbeMatched();
+            }
+
             ++$context->index;
             WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
@@ -65,6 +77,13 @@ final class ChildWorkflowStub
                 throw $throwable;
             }
             return resolve($result);
+        }
+
+        if (WorkflowStub::isProbing()) {
+            ++$context->index;
+            WorkflowStub::setContext($context);
+            $deferred = new Deferred();
+            return $deferred->promise();
         }
 
         if (! $context->replaying) {

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -22,9 +22,11 @@ final class ChildWorkflowStub
     public static function make($workflow, ...$arguments): PromiseInterface
     {
         $context = WorkflowStub::getContext();
+        $result = null;
 
         while (true) {
             $log = $context->storedWorkflow->findLogByIndex($context->index);
+            $result = null;
 
             if (WorkflowStub::faked()) {
                 $mocks = WorkflowStub::mocks();
@@ -45,10 +47,17 @@ final class ChildWorkflowStub
                 }
             }
 
-            if (! $log || ! ($log->class === Exception::class && self::isForeignExceptionResult(
-                Serializer::unserialize($log->result),
-                $workflow
-            ))) {
+            if (! $log) {
+                break;
+            }
+
+            if ($log->class !== Exception::class) {
+                break;
+            }
+
+            $result = Serializer::unserialize($log->result);
+
+            if (! self::isForeignExceptionResult($result, $workflow)) {
                 break;
             }
 
@@ -57,7 +66,7 @@ final class ChildWorkflowStub
         }
 
         if ($log) {
-            $result = Serializer::unserialize($log->result);
+            $result ??= Serializer::unserialize($log->result);
 
             if (
                 WorkflowStub::isProbing()

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -60,6 +60,9 @@ final class ChildWorkflowStub
             ++$context->index;
             WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
+            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $workflow)) {
+                return self::make($workflow, ...$arguments);
+            }
             if (
                 is_array($result)
                 && array_key_exists('class', $result)
@@ -113,5 +116,13 @@ final class ChildWorkflowStub
         ++$context->index;
         WorkflowStub::setContext($context);
         return (new Deferred())->promise();
+    }
+
+    private static function isForeignExceptionResult(mixed $result, string $workflow): bool
+    {
+        return is_array($result)
+            && isset($result['sourceClass'])
+            && is_string($result['sourceClass'])
+            && $result['sourceClass'] !== $workflow;
     }
 }

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -88,6 +88,7 @@ final class ChildWorkflowStub
         }
 
         if (WorkflowStub::isProbing()) {
+            WorkflowStub::markProbePendingBeforeMatch();
             ++$context->index;
             WorkflowStub::setContext($context);
             return (new Deferred())->promise();

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -45,6 +45,15 @@ final class ChildWorkflowStub
         }
 
         if ($log) {
+            $result = Serializer::unserialize($log->result);
+
+            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $workflow)) {
+                ++$context->index;
+                WorkflowStub::setContext($context);
+
+                return self::make($workflow, ...$arguments);
+            }
+
             if (
                 WorkflowStub::isProbing()
                 && WorkflowStub::probeIndex() === $context->index
@@ -59,10 +68,6 @@ final class ChildWorkflowStub
 
             ++$context->index;
             WorkflowStub::setContext($context);
-            $result = Serializer::unserialize($log->result);
-            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $workflow)) {
-                return self::make($workflow, ...$arguments);
-            }
             if (
                 is_array($result)
                 && array_key_exists('class', $result)

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -82,8 +82,7 @@ final class ChildWorkflowStub
         if (WorkflowStub::isProbing()) {
             ++$context->index;
             WorkflowStub::setContext($context);
-            $deferred = new Deferred();
-            return $deferred->promise();
+            return (new Deferred())->promise();
         }
 
         if (! $context->replaying) {
@@ -113,7 +112,6 @@ final class ChildWorkflowStub
 
         ++$context->index;
         WorkflowStub::setContext($context);
-        $deferred = new Deferred();
-        return $deferred->promise();
+        return (new Deferred())->promise();
     }
 }

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -32,14 +32,14 @@ final class ChildWorkflowStub
                 $mocks = WorkflowStub::mocks();
 
                 if (! $log && array_key_exists($workflow, $mocks)) {
-                    $result = $mocks[$workflow];
+                    $mockedResult = $mocks[$workflow];
 
                     $log = $context->storedWorkflow->createLog([
                         'index' => $context->index,
                         'now' => $context->now,
                         'class' => $workflow,
                         'result' => Serializer::serialize(
-                            is_callable($result) ? $result($context, ...$arguments) : $result
+                            is_callable($mockedResult) ? $mockedResult($context, ...$arguments) : $mockedResult
                         ),
                     ]);
 

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -23,36 +23,41 @@ final class ChildWorkflowStub
     {
         $context = WorkflowStub::getContext();
 
-        $log = $context->storedWorkflow->findLogByIndex($context->index);
+        while (true) {
+            $log = $context->storedWorkflow->findLogByIndex($context->index);
 
-        if (WorkflowStub::faked()) {
-            $mocks = WorkflowStub::mocks();
+            if (WorkflowStub::faked()) {
+                $mocks = WorkflowStub::mocks();
 
-            if (! $log && array_key_exists($workflow, $mocks)) {
-                $result = $mocks[$workflow];
+                if (! $log && array_key_exists($workflow, $mocks)) {
+                    $result = $mocks[$workflow];
 
-                $log = $context->storedWorkflow->createLog([
-                    'index' => $context->index,
-                    'now' => $context->now,
-                    'class' => $workflow,
-                    'result' => Serializer::serialize(
-                        is_callable($result) ? $result($context, ...$arguments) : $result
-                    ),
-                ]);
+                    $log = $context->storedWorkflow->createLog([
+                        'index' => $context->index,
+                        'now' => $context->now,
+                        'class' => $workflow,
+                        'result' => Serializer::serialize(
+                            is_callable($result) ? $result($context, ...$arguments) : $result
+                        ),
+                    ]);
 
-                WorkflowStub::recordDispatched($workflow, $arguments);
+                    WorkflowStub::recordDispatched($workflow, $arguments);
+                }
             }
+
+            if (! $log || ! ($log->class === Exception::class && self::isForeignExceptionResult(
+                Serializer::unserialize($log->result),
+                $workflow
+            ))) {
+                break;
+            }
+
+            ++$context->index;
+            WorkflowStub::setContext($context);
         }
 
         if ($log) {
             $result = Serializer::unserialize($log->result);
-
-            if ($log->class === Exception::class && self::isForeignExceptionResult($result, $workflow)) {
-                ++$context->index;
-                WorkflowStub::setContext($context);
-
-                return self::make($workflow, ...$arguments);
-            }
 
             if (
                 WorkflowStub::isProbing()

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -58,7 +58,6 @@ final class ChildWorkflowStub
             }
 
             ++$context->index;
-            WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
             if (
                 is_array($result)
@@ -81,7 +80,6 @@ final class ChildWorkflowStub
 
         if (WorkflowStub::isProbing()) {
             ++$context->index;
-            WorkflowStub::setContext($context);
             return (new Deferred())->promise();
         }
 
@@ -111,7 +109,6 @@ final class ChildWorkflowStub
         }
 
         ++$context->index;
-        WorkflowStub::setContext($context);
         return (new Deferred())->promise();
     }
 }

--- a/src/ChildWorkflowStub.php
+++ b/src/ChildWorkflowStub.php
@@ -58,6 +58,7 @@ final class ChildWorkflowStub
             }
 
             ++$context->index;
+            WorkflowStub::setContext($context);
             $result = Serializer::unserialize($log->result);
             if (
                 is_array($result)
@@ -80,6 +81,7 @@ final class ChildWorkflowStub
 
         if (WorkflowStub::isProbing()) {
             ++$context->index;
+            WorkflowStub::setContext($context);
             return (new Deferred())->promise();
         }
 
@@ -109,6 +111,7 @@ final class ChildWorkflowStub
         }
 
         ++$context->index;
+        WorkflowStub::setContext($context);
         return (new Deferred())->promise();
     }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -28,6 +28,12 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
 
     private const LOCK_RETRY_DELAY = 1;
 
+    private const PROBE_SKIP = 'skip';
+
+    private const PROBE_PERSIST = 'persist';
+
+    private const PROBE_RETRY = 'retry';
+
     public ?string $key = null;
 
     public $tries = PHP_INT_MAX;
@@ -70,8 +76,14 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             try {
                 if ($this->storedWorkflow->hasLogByIndex($this->index)) {
                     $workflow->resume();
-                } elseif ($this->shouldPersistAfterProbeReplay()) {
-                    $workflow->next($this->index, $this->now, self::class, $this->exceptionPayload());
+                } else {
+                    $probeDecision = $this->probeReplayDecision();
+
+                    if ($probeDecision === self::PROBE_PERSIST) {
+                        $workflow->next($this->index, $this->now, self::class, $this->exceptionPayload());
+                    } elseif ($probeDecision === self::PROBE_RETRY) {
+                        $this->release(self::LOCK_RETRY_DELAY);
+                    }
                 }
             } catch (TransitionNotFound) {
                 if ($workflow->running()) {
@@ -95,28 +107,28 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         ];
     }
 
-    private function shouldPersistAfterProbeReplay(): bool
+    private function probeReplayDecision(): string
     {
         $workflowClass = $this->storedWorkflow->class;
 
         if (! is_string($workflowClass) || $workflowClass === '') {
-            return true;
+            return self::PROBE_PERSIST;
         }
 
         try {
             if (! class_exists($workflowClass) || ! is_subclass_of($workflowClass, Workflow::class)) {
-                return true;
+                return self::PROBE_PERSIST;
             }
 
             if (! (new ReflectionClass($workflowClass))->isInstantiable()) {
-                return true;
+                return self::PROBE_PERSIST;
             }
         } catch (Throwable) {
-            return true;
+            return self::PROBE_PERSIST;
         }
 
         $previousContext = WorkflowStub::getContext();
-        $shouldPersist = false;
+        $probeDecision = self::PROBE_SKIP;
 
         try {
             $tentativeWorkflow = $this->createTentativeWorkflowState();
@@ -132,6 +144,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
                 'probeIndex' => $this->index,
                 'probeClass' => $this->sourceClass,
                 'probeMatched' => false,
+                'probePendingBeforeMatch' => false,
             ]);
 
             try {
@@ -140,12 +153,16 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
                 // The replay path may still throw; we only care whether it matched this tentative log.
             }
 
-            $shouldPersist = WorkflowStub::probeMatched();
+            if (WorkflowStub::probeMatched()) {
+                $probeDecision = WorkflowStub::probePendingBeforeMatch()
+                    ? self::PROBE_RETRY
+                    : self::PROBE_PERSIST;
+            }
         } finally {
             WorkflowStub::setContext($previousContext);
         }
 
-        return $shouldPersist;
+        return $probeDecision;
     }
 
     private function createTentativeWorkflowState(): StoredWorkflow

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -195,7 +195,6 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             'logs',
             $tentativeWorkflow->getRelation('logs')
                 ->push($tentativeLog)
-                ->sortBy(static fn ($log): string => sprintf('%020d:%020d', $log->index, $log->id ?? PHP_INT_MAX))
                 ->values()
         );
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -15,6 +15,7 @@ use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Serializer;
 
 final class Exception implements ShouldBeEncrypted, ShouldQueue
@@ -100,10 +101,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         }
 
         $previousContext = WorkflowStub::getContext();
-        $connection = $this->storedWorkflow->getConnection();
         $shouldPersist = false;
-
-        $connection->beginTransaction();
 
         try {
             $tentativeWorkflow = $this->createTentativeWorkflowState();
@@ -130,10 +128,6 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             $shouldPersist = WorkflowStub::probeMatched();
         } finally {
             WorkflowStub::setContext($previousContext);
-
-            if ($connection->transactionLevel() > 0) {
-                $connection->rollBack();
-            }
         }
 
         return $shouldPersist;
@@ -141,16 +135,32 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
 
     private function createTentativeWorkflowState(): StoredWorkflow
     {
-        $this->storedWorkflow->createLog([
-            'index' => $this->index,
-            'now' => $this->now,
-            'class' => self::class,
-            'result' => Serializer::serialize($this->exceptionPayload()),
-        ]);
-
         $storedWorkflowClass = $this->storedWorkflow::class;
 
-        return $storedWorkflowClass::query()->findOrFail($this->storedWorkflow->id);
+        /** @var StoredWorkflow $tentativeWorkflow */
+        $tentativeWorkflow = $storedWorkflowClass::query()
+            ->findOrFail($this->storedWorkflow->id);
+
+        $tentativeWorkflow->loadMissing(['logs', 'signals']);
+
+        /** @var StoredWorkflowLog $tentativeLog */
+        $tentativeLog = $tentativeWorkflow->logs()
+            ->make([
+                'index' => $this->index,
+                'now' => $this->now,
+                'class' => self::class,
+                'result' => Serializer::serialize($this->exceptionPayload()),
+            ]);
+
+        $tentativeWorkflow->setRelation(
+            'logs',
+            $tentativeWorkflow->getRelation('logs')
+                ->push($tentativeLog)
+                ->sortBy(static fn ($log): string => sprintf('%020d:%020d', $log->index, $log->id ?? PHP_INT_MAX))
+                ->values()
+        );
+
+        return $tentativeWorkflow;
     }
 
     private function exceptionPayload()

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,7 +13,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
-use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Serializer;
@@ -82,14 +81,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
 
     public function middleware()
     {
-        return [
-            new WithoutOverlappingMiddleware(
-                $this->storedWorkflow->id,
-                WithoutOverlappingMiddleware::ACTIVITY,
-                0,
-                15
-            ),
-        ];
+        return [];
     }
 
     private function shouldPersistAfterProbeReplay(): bool

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,9 +10,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Serializer;
 
 final class Exception implements ShouldBeEncrypted, ShouldQueue
 {
@@ -35,7 +37,8 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         public StoredWorkflow $storedWorkflow,
         public $exception,
         $connection = null,
-        $queue = null
+        $queue = null,
+        public ?string $sourceClass = null
     ) {
         $connection = $connection ?? $this->storedWorkflow->effectiveConnection() ?? config('queue.default');
         $queue = $queue ?? $this->storedWorkflow->effectiveQueue() ?? config(
@@ -53,7 +56,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         try {
             if ($this->storedWorkflow->hasLogByIndex($this->index)) {
                 $workflow->resume();
-            } elseif (! $this->storedWorkflow->logs()->where('class', self::class)->exists()) {
+            } elseif ($this->shouldPersistAfterProbeReplay()) {
                 $workflow->next($this->index, $this->now, self::class, $this->exception);
             }
         } catch (TransitionNotFound) {
@@ -73,5 +76,67 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
                 15
             ),
         ];
+    }
+
+    private function shouldPersistAfterProbeReplay(): bool
+    {
+        $workflowClass = $this->storedWorkflow->class;
+
+        if (! is_string($workflowClass) || $workflowClass === '') {
+            return true;
+        }
+
+        $previousContext = WorkflowStub::getContext();
+        $connection = $this->storedWorkflow->getConnection();
+        $shouldPersist = false;
+
+        $connection->beginTransaction();
+
+        try {
+            $tentativeWorkflow = $this->createTentativeWorkflowState();
+            $workflow = new $workflowClass($tentativeWorkflow, ...$tentativeWorkflow->workflowArguments());
+            $workflow->replaying = true;
+
+            WorkflowStub::setContext([
+                'storedWorkflow' => $tentativeWorkflow,
+                'index' => 0,
+                'now' => $this->now,
+                'replaying' => true,
+                'probing' => true,
+                'probeIndex' => $this->index,
+                'probeClass' => $this->sourceClass,
+                'probeMatched' => false,
+            ]);
+
+            try {
+                $workflow->handle();
+            } catch (Throwable) {
+                // The replay path may still throw; we only care whether it matched this tentative log.
+            }
+
+            $shouldPersist = WorkflowStub::probeMatched();
+        } finally {
+            WorkflowStub::setContext($previousContext);
+
+            if ($connection->transactionLevel() > 0) {
+                $connection->rollBack();
+            }
+        }
+
+        return $shouldPersist;
+    }
+
+    private function createTentativeWorkflowState(): StoredWorkflow
+    {
+        $this->storedWorkflow->createLog([
+            'index' => $this->index,
+            'now' => $this->now,
+            'class' => self::class,
+            'result' => Serializer::serialize($this->exception),
+        ]);
+
+        $storedWorkflowClass = $this->storedWorkflow::class;
+
+        return $storedWorkflowClass::query()->findOrFail($this->storedWorkflow->id);
     }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
+use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Models\StoredWorkflowLog;
 use Workflow\Serializers\Serializer;
@@ -81,7 +82,14 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
 
     public function middleware()
     {
-        return [];
+        return [
+            new WithoutOverlappingMiddleware(
+                $this->storedWorkflow->id,
+                WithoutOverlappingMiddleware::WORKFLOW,
+                0,
+                15
+            ),
+        ];
     }
 
     private function shouldPersistAfterProbeReplay(): bool

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
+use ReflectionClass;
 use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
@@ -97,6 +98,18 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         $workflowClass = $this->storedWorkflow->class;
 
         if (! is_string($workflowClass) || $workflowClass === '') {
+            return true;
+        }
+
+        try {
+            if (! class_exists($workflowClass) || ! is_subclass_of($workflowClass, Workflow::class)) {
+                return true;
+            }
+
+            if (! (new ReflectionClass($workflowClass))->isInstantiable()) {
+                return true;
+            }
+        } catch (Throwable) {
             return true;
         }
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use ReflectionClass;
 use Throwable;
@@ -138,7 +139,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             WorkflowStub::setContext([
                 'storedWorkflow' => $tentativeWorkflow,
                 'index' => 0,
-                'now' => $this->now,
+                'now' => Carbon::parse($this->now),
                 'replaying' => true,
                 'probing' => true,
                 'probeIndex' => $this->index,

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -26,6 +26,8 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    private const LOCK_RETRY_DELAY = 1;
+
     public ?string $key = null;
 
     public $tries = PHP_INT_MAX;
@@ -57,7 +59,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         $lock = Cache::lock('laravel-workflow-exception:' . $this->storedWorkflow->id, 15);
 
         if (! $lock->get()) {
-            $this->release();
+            $this->release(self::LOCK_RETRY_DELAY);
 
             return;
         }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
 use Throwable;
 use Workflow\Exceptions\TransitionNotFound;
 use Workflow\Middleware\WithoutOverlappingMiddleware;
@@ -51,18 +52,30 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
 
     public function handle()
     {
-        $workflow = $this->storedWorkflow->toWorkflow();
+        $lock = Cache::lock('laravel-workflow-exception:' . $this->storedWorkflow->id, 15);
+
+        if (! $lock->get()) {
+            $this->release();
+
+            return;
+        }
 
         try {
-            if ($this->storedWorkflow->hasLogByIndex($this->index)) {
-                $workflow->resume();
-            } elseif ($this->shouldPersistAfterProbeReplay()) {
-                $workflow->next($this->index, $this->now, self::class, $this->exception);
+            $workflow = $this->storedWorkflow->toWorkflow();
+
+            try {
+                if ($this->storedWorkflow->hasLogByIndex($this->index)) {
+                    $workflow->resume();
+                } elseif ($this->shouldPersistAfterProbeReplay()) {
+                    $workflow->next($this->index, $this->now, self::class, $this->exceptionPayload());
+                }
+            } catch (TransitionNotFound) {
+                if ($workflow->running()) {
+                    $this->release();
+                }
             }
-        } catch (TransitionNotFound) {
-            if ($workflow->running()) {
-                $this->release();
-            }
+        } finally {
+            $lock->release();
         }
     }
 
@@ -132,11 +145,22 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             'index' => $this->index,
             'now' => $this->now,
             'class' => self::class,
-            'result' => Serializer::serialize($this->exception),
+            'result' => Serializer::serialize($this->exceptionPayload()),
         ]);
 
         $storedWorkflowClass = $this->storedWorkflow::class;
 
         return $storedWorkflowClass::query()->findOrFail($this->storedWorkflow->id);
+    }
+
+    private function exceptionPayload()
+    {
+        if (! is_array($this->exception) || $this->sourceClass === null) {
+            return $this->exception;
+        }
+
+        return array_merge($this->exception, [
+            'sourceClass' => $this->sourceClass,
+        ]);
     }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -102,7 +102,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             new WithoutOverlappingMiddleware(
                 $this->storedWorkflow->id,
                 WithoutOverlappingMiddleware::WORKFLOW,
-                0,
+                self::LOCK_RETRY_DELAY,
                 15
             ),
         ];
@@ -132,6 +132,12 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
         $probeDecision = self::PROBE_SKIP;
 
         try {
+            try {
+                $probeNow = Carbon::parse($this->now);
+            } catch (Throwable) {
+                return self::PROBE_PERSIST;
+            }
+
             $tentativeWorkflow = $this->createTentativeWorkflowState();
             $workflow = new $workflowClass($tentativeWorkflow, ...$tentativeWorkflow->workflowArguments());
             $workflow->replaying = true;
@@ -139,7 +145,7 @@ final class Exception implements ShouldBeEncrypted, ShouldQueue
             WorkflowStub::setContext([
                 'storedWorkflow' => $tentativeWorkflow,
                 'index' => 0,
-                'now' => Carbon::parse($this->now),
+                'now' => $probeNow,
                 'replaying' => true,
                 'probing' => true,
                 'probeIndex' => $this->index,

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -24,8 +24,7 @@ trait Awaits
 
         if (self::isProbing()) {
             ++self::$context->index;
-            $deferred = new Deferred();
-            return $deferred->promise();
+            return (new Deferred())->promise();
         }
 
         $result = $condition();
@@ -55,7 +54,6 @@ trait Awaits
         }
 
         ++self::$context->index;
-        $deferred = new Deferred();
-        return $deferred->promise();
+        return (new Deferred())->promise();
     }
 }

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -23,6 +23,7 @@ trait Awaits
         }
 
         if (self::isProbing()) {
+            self::markProbePendingBeforeMatch();
             ++self::$context->index;
             return (new Deferred())->promise();
         }

--- a/src/Traits/Awaits.php
+++ b/src/Traits/Awaits.php
@@ -22,6 +22,12 @@ trait Awaits
             return resolve(Serializer::unserialize($log->result));
         }
 
+        if (self::isProbing()) {
+            ++self::$context->index;
+            $deferred = new Deferred();
+            return $deferred->promise();
+        }
+
         $result = $condition();
 
         if ($result === true) {

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -22,6 +22,7 @@ trait SideEffects
         }
 
         if (self::isProbing()) {
+            self::markProbePendingBeforeMatch();
             ++self::$context->index;
             return (new Deferred())->promise();
         }

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workflow\Traits;
 
 use Illuminate\Database\QueryException;
+use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Workflow\Serializers\Serializer;
@@ -22,7 +23,7 @@ trait SideEffects
 
         if (self::isProbing()) {
             ++self::$context->index;
-            return (new \React\Promise\Deferred())->promise();
+            return (new Deferred())->promise();
         }
 
         $result = $callable();

--- a/src/Traits/SideEffects.php
+++ b/src/Traits/SideEffects.php
@@ -20,6 +20,11 @@ trait SideEffects
             return resolve(Serializer::unserialize($log->result));
         }
 
+        if (self::isProbing()) {
+            ++self::$context->index;
+            return (new \React\Promise\Deferred())->promise();
+        }
+
         $result = $callable();
 
         if (! self::$context->replaying) {

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -41,6 +41,12 @@ trait Timers
             $when = self::$context->now->copy()
                 ->addSeconds($seconds);
 
+            if (self::isProbing()) {
+                ++self::$context->index;
+                $deferred = new Deferred();
+                return $deferred->promise();
+            }
+
             if (! self::$context->replaying) {
                 $timer = self::$context->storedWorkflow->createTimer([
                     'index' => self::$context->index,

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -43,8 +43,7 @@ trait Timers
 
             if (self::isProbing()) {
                 ++self::$context->index;
-                $deferred = new Deferred();
-                return $deferred->promise();
+                return (new Deferred())->promise();
             }
 
             if (! self::$context->replaying) {
@@ -54,8 +53,7 @@ trait Timers
                 ]);
             } else {
                 ++self::$context->index;
-                $deferred = new Deferred();
-                return $deferred->promise();
+                return (new Deferred())->promise();
             }
         }
 
@@ -101,7 +99,6 @@ trait Timers
         }
 
         ++self::$context->index;
-        $deferred = new Deferred();
-        return $deferred->promise();
+        return (new Deferred())->promise();
     }
 }

--- a/src/Traits/Timers.php
+++ b/src/Traits/Timers.php
@@ -42,6 +42,7 @@ trait Timers
                 ->addSeconds($seconds);
 
             if (self::isProbing()) {
+                self::markProbePendingBeforeMatch();
                 ++self::$context->index;
                 return (new Deferred())->promise();
             }
@@ -96,6 +97,10 @@ trait Timers
                 self::connection(),
                 self::queue()
             )->delay($delay);
+        }
+
+        if (self::isProbing()) {
+            self::markProbePendingBeforeMatch();
         }
 
         ++self::$context->index;

--- a/src/Traits/Versions.php
+++ b/src/Traits/Versions.php
@@ -35,6 +35,7 @@ trait Versions
         }
 
         if (self::isProbing()) {
+            self::markProbePendingBeforeMatch();
             ++self::$context->index;
             return (new Deferred())->promise();
         }

--- a/src/Traits/Versions.php
+++ b/src/Traits/Versions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workflow\Traits;
 
 use Illuminate\Database\QueryException;
+use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 use Workflow\Exceptions\VersionNotSupportedException;
@@ -35,7 +36,7 @@ trait Versions
 
         if (self::isProbing()) {
             ++self::$context->index;
-            return (new \React\Promise\Deferred())->promise();
+            return (new Deferred())->promise();
         }
 
         $version = $maxSupported;

--- a/src/Traits/Versions.php
+++ b/src/Traits/Versions.php
@@ -33,6 +33,11 @@ trait Versions
             return resolve($version);
         }
 
+        if (self::isProbing()) {
+            ++self::$context->index;
+            return (new \React\Promise\Deferred())->promise();
+        }
+
         $version = $maxSupported;
 
         if (! self::$context->replaying) {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -209,7 +209,7 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
             $this->now = $log ? $log->now : Carbon::now();
         }
 
-        WorkflowStub::setContext([
+        $this->setContext([
             'storedWorkflow' => $this->storedWorkflow,
             'index' => $this->index,
             'now' => $this->now,
@@ -229,7 +229,7 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
 
             $this->now = $log ? $log->now : Carbon::now();
 
-            WorkflowStub::setContext([
+            $this->setContext([
                 'storedWorkflow' => $this->storedWorkflow,
                 'index' => $this->index,
                 'now' => $this->now,
@@ -308,5 +308,19 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
                 );
             }
         }
+    }
+
+    private function setContext(array $context): void
+    {
+        $existingContext = WorkflowStub::getContext();
+
+        if (property_exists($existingContext, 'probing') && $existingContext->probing) {
+            $context['probing'] = true;
+            $context['probeIndex'] = $existingContext->probeIndex ?? null;
+            $context['probeClass'] = $existingContext->probeClass ?? null;
+            $context['probeMatched'] = $existingContext->probeMatched ?? false;
+        }
+
+        WorkflowStub::setContext($context);
     }
 }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -323,6 +323,7 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
             $context['probeIndex'] = $existingContext->probeIndex ?? null;
             $context['probeClass'] = $existingContext->probeClass ?? null;
             $context['probeMatched'] = $existingContext->probeMatched ?? false;
+            $context['probePendingBeforeMatch'] = $existingContext->probePendingBeforeMatch ?? false;
         }
 
         WorkflowStub::setContext($context);

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -198,9 +198,23 @@ final class WorkflowStub
         self::$context->probeMatched = true;
     }
 
+    public static function markProbePendingBeforeMatch(): void
+    {
+        if (! self::isProbing() || self::probeMatched()) {
+            return;
+        }
+
+        self::$context->probePendingBeforeMatch = true;
+    }
+
     public static function probeMatched(): bool
     {
         return (bool) (self::getContext()->probeMatched ?? false);
+    }
+
+    public static function probePendingBeforeMatch(): bool
+    {
+        return (bool) (self::getContext()->probePendingBeforeMatch ?? false);
     }
 
     public function id()

--- a/src/WorkflowStub.php
+++ b/src/WorkflowStub.php
@@ -157,6 +157,10 @@ final class WorkflowStub
 
     public static function getContext(): \stdClass
     {
+        if (self::$context === null) {
+            self::$context = new \stdClass();
+        }
+
         return self::$context;
     }
 
@@ -168,6 +172,35 @@ final class WorkflowStub
     public static function now()
     {
         return self::getContext()->now;
+    }
+
+    public static function isProbing(): bool
+    {
+        return (bool) (self::getContext()->probing ?? false);
+    }
+
+    public static function probeIndex(): ?int
+    {
+        return self::getContext()->probeIndex ?? null;
+    }
+
+    public static function probeClass(): ?string
+    {
+        return self::getContext()->probeClass ?? null;
+    }
+
+    public static function markProbeMatched(): void
+    {
+        if (! self::isProbing()) {
+            return;
+        }
+
+        self::$context->probeMatched = true;
+    }
+
+    public static function probeMatched(): bool
+    {
+        return (bool) (self::getContext()->probeMatched ?? false);
     }
 
     public function id()
@@ -287,7 +320,7 @@ final class WorkflowStub
             ->format('Y-m-d\TH:i:s.u\Z'));
 
         $this->storedWorkflow->parents()
-            ->each(static function ($parentWorkflow) use ($exception) {
+            ->each(function ($parentWorkflow) use ($exception) {
                 if (
                     $parentWorkflow->pivot->parent_index === StoredWorkflow::CONTINUE_PARENT_INDEX
                     || $parentWorkflow->pivot->parent_index === StoredWorkflow::ACTIVE_WORKFLOW_INDEX
@@ -324,7 +357,8 @@ final class WorkflowStub
                     $parentWorkflow,
                     $throwable,
                     $parentWf->connection(),
-                    $parentWf->queue()
+                    $parentWf->queue(),
+                    $this->storedWorkflow->class
                 );
             });
     }

--- a/tests/Feature/ExceptionLoggingReplayTest.php
+++ b/tests/Feature/ExceptionLoggingReplayTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\Fixtures\TestProbeBackToBackWorkflow;
+use Tests\Fixtures\TestProbeChildFailureCompensationActivity;
+use Tests\Fixtures\TestProbeChildFailureParentStepActivity;
+use Tests\Fixtures\TestProbeChildFailureParentWorkflow;
+use Tests\Fixtures\TestProbeRetryActivity;
+use Tests\Fixtures\TestProbeRetryWorkflow;
+use Tests\TestCase;
+use Workflow\Exception;
+use Workflow\Signal;
+use Workflow\States\WorkflowCompletedStatus;
+use Workflow\WorkflowStub;
+
+final class ExceptionLoggingReplayTest extends TestCase
+{
+    public function testSignalRetryLogsEachSequentialException(): void
+    {
+        $workflow = WorkflowStub::make(TestProbeRetryWorkflow::class);
+
+        $workflow->start();
+
+        sleep(1);
+        $workflow->requestRetry();
+
+        sleep(1);
+        $workflow->requestRetry();
+
+        while ($workflow->running());
+
+        $classes = $workflow->logs()
+            ->pluck('class')
+            ->all();
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('success', $workflow->output());
+        $this->assertSame([
+            Exception::class,
+            Signal::class,
+            Exception::class,
+            Signal::class,
+            TestProbeRetryActivity::class,
+        ], $classes);
+    }
+
+    public function testBackToBackCaughtExceptionsEachPersist(): void
+    {
+        $workflow = WorkflowStub::make(TestProbeBackToBackWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $classes = $workflow->logs()
+            ->pluck('class')
+            ->all();
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('caught second: second failure', $workflow->output());
+        $this->assertSame([Exception::class, Exception::class], $classes);
+    }
+
+    public function testParallelChildFailuresStillDeduplicateToOneParentException(): void
+    {
+        $workflow = WorkflowStub::make(TestProbeChildFailureParentWorkflow::class);
+
+        $workflow->start();
+
+        while ($workflow->running());
+
+        $classes = $workflow->logs()
+            ->pluck('class')
+            ->all();
+
+        $this->assertSame(WorkflowCompletedStatus::class, $workflow->status());
+        $this->assertSame('caught: child failed: child-1', $workflow->output());
+        $this->assertSame([
+            TestProbeChildFailureParentStepActivity::class,
+            Exception::class,
+            TestProbeChildFailureCompensationActivity::class,
+        ], $classes);
+        $this->assertSame(1, $workflow->logs()->where('class', Exception::class)->count());
+    }
+}

--- a/tests/Fixtures/TestProbeBackToBackWorkflow.php
+++ b/tests/Fixtures/TestProbeBackToBackWorkflow.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Throwable;
+use Workflow\Workflow;
+use function Workflow\activity;
+
+final class TestProbeBackToBackWorkflow extends Workflow
+{
+    public function execute()
+    {
+        try {
+            yield activity(TestProbeRetryActivity::class, 1);
+        } catch (Throwable) {
+        }
+
+        try {
+            yield activity(TestProbeRetryActivity::class, 2);
+        } catch (Throwable $throwable) {
+            return 'caught second: ' . $throwable->getMessage();
+        }
+
+        return 'unexpected-success';
+    }
+}

--- a/tests/Fixtures/TestProbeBackToBackWorkflow.php
+++ b/tests/Fixtures/TestProbeBackToBackWorkflow.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Throwable;
-use Workflow\Workflow;
 use function Workflow\activity;
+use Workflow\Workflow;
 
 final class TestProbeBackToBackWorkflow extends Workflow
 {

--- a/tests/Fixtures/TestProbeChildFailureCompensationActivity.php
+++ b/tests/Fixtures/TestProbeChildFailureCompensationActivity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestProbeChildFailureCompensationActivity extends Activity
+{
+    public function execute(): string
+    {
+        return 'compensated';
+    }
+}

--- a/tests/Fixtures/TestProbeChildFailureParentStepActivity.php
+++ b/tests/Fixtures/TestProbeChildFailureParentStepActivity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Workflow\Activity;
+
+final class TestProbeChildFailureParentStepActivity extends Activity
+{
+    public function execute(): string
+    {
+        return 'prepared';
+    }
+}

--- a/tests/Fixtures/TestProbeChildFailureParentWorkflow.php
+++ b/tests/Fixtures/TestProbeChildFailureParentWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Throwable;
+use Workflow\Workflow;
+use function Workflow\activity;
+use function Workflow\all;
+use function Workflow\child;
+
+final class TestProbeChildFailureParentWorkflow extends Workflow
+{
+    public function execute()
+    {
+        try {
+            yield activity(TestProbeChildFailureParentStepActivity::class);
+
+            $this->addCompensation(fn () => activity(TestProbeChildFailureCompensationActivity::class));
+
+            yield all([
+                child(TestProbeChildFailureWorkflow::class, 'child-1'),
+                child(TestProbeChildFailureWorkflow::class, 'child-2'),
+                child(TestProbeChildFailureWorkflow::class, 'child-3'),
+            ]);
+
+            return 'unexpected-success';
+        } catch (Throwable $throwable) {
+            yield from $this->compensate();
+
+            return 'caught: ' . $throwable->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/TestProbeChildFailureParentWorkflow.php
+++ b/tests/Fixtures/TestProbeChildFailureParentWorkflow.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Throwable;
-use Workflow\Workflow;
 use function Workflow\activity;
 use function Workflow\all;
 use function Workflow\child;
+use Workflow\Workflow;
 
 final class TestProbeChildFailureParentWorkflow extends Workflow
 {
@@ -17,7 +17,7 @@ final class TestProbeChildFailureParentWorkflow extends Workflow
         try {
             yield activity(TestProbeChildFailureParentStepActivity::class);
 
-            $this->addCompensation(fn () => activity(TestProbeChildFailureCompensationActivity::class));
+            $this->addCompensation(static fn () => activity(TestProbeChildFailureCompensationActivity::class));
 
             yield all([
                 child(TestProbeChildFailureWorkflow::class, 'child-1'),

--- a/tests/Fixtures/TestProbeChildFailureWorkflow.php
+++ b/tests/Fixtures/TestProbeChildFailureWorkflow.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use RuntimeException;
+use Workflow\Workflow;
+
+final class TestProbeChildFailureWorkflow extends Workflow
+{
+    public function execute(string $child)
+    {
+        throw new RuntimeException("child failed: {$child}");
+    }
+}

--- a/tests/Fixtures/TestProbeNowSignalWorkflow.php
+++ b/tests/Fixtures/TestProbeNowSignalWorkflow.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Illuminate\Support\Carbon;
+use Workflow\SignalMethod;
+use Workflow\Workflow;
+use Workflow\WorkflowStub;
+
+final class TestProbeNowSignalWorkflow extends Workflow
+{
+    public static bool $signalSawCarbonNow = false;
+
+    #[SignalMethod]
+    public function recordNowType(): void
+    {
+        self::$signalSawCarbonNow = WorkflowStub::now() instanceof Carbon;
+    }
+
+    public function execute()
+    {
+        if (false) {
+            yield;
+        }
+
+        return 'ok';
+    }
+}

--- a/tests/Fixtures/TestProbeParallelChildWorkflow.php
+++ b/tests/Fixtures/TestProbeParallelChildWorkflow.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Throwable;
+use Workflow\Workflow;
+use function Workflow\all;
+use function Workflow\child;
+
+final class TestProbeParallelChildWorkflow extends Workflow
+{
+    public function execute()
+    {
+        try {
+            yield all([
+                child(TestProbeChildFailureWorkflow::class, 'child-1'),
+                child(TestProbeChildFailureWorkflow::class, 'child-2'),
+            ]);
+
+            return 'unexpected-success';
+        } catch (Throwable) {
+            return 'caught';
+        }
+    }
+}

--- a/tests/Fixtures/TestProbeParallelChildWorkflow.php
+++ b/tests/Fixtures/TestProbeParallelChildWorkflow.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Throwable;
-use Workflow\Workflow;
 use function Workflow\all;
 use function Workflow\child;
+use Workflow\Workflow;
 
 final class TestProbeParallelChildWorkflow extends Workflow
 {

--- a/tests/Fixtures/TestProbeRetryActivity.php
+++ b/tests/Fixtures/TestProbeRetryActivity.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Workflow\Activity;
+
+final class TestProbeRetryActivity extends Activity
+{
+    public $tries = 1;
+
+    public function execute(int $attempt): string
+    {
+        return match ($attempt) {
+            1 => throw new RuntimeException('first failure'),
+            2 => throw new InvalidArgumentException('second failure'),
+            default => 'success',
+        };
+    }
+}

--- a/tests/Fixtures/TestProbeRetryWorkflow.php
+++ b/tests/Fixtures/TestProbeRetryWorkflow.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Fixtures;
 
 use Throwable;
-use Workflow\SignalMethod;
-use Workflow\Workflow;
 use function Workflow\activity;
 use function Workflow\await;
+use Workflow\SignalMethod;
+use Workflow\Workflow;
 
 final class TestProbeRetryWorkflow extends Workflow
 {

--- a/tests/Fixtures/TestProbeRetryWorkflow.php
+++ b/tests/Fixtures/TestProbeRetryWorkflow.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Throwable;
+use Workflow\SignalMethod;
+use Workflow\Workflow;
+use function Workflow\activity;
+use function Workflow\await;
+
+final class TestProbeRetryWorkflow extends Workflow
+{
+    #[SignalMethod]
+    public function requestRetry(): void
+    {
+        $this->inbox->receive('retry');
+    }
+
+    public function execute()
+    {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                ++$attempt;
+
+                return yield activity(TestProbeRetryActivity::class, $attempt);
+            } catch (Throwable $throwable) {
+                if ($attempt >= 3) {
+                    throw $throwable;
+                }
+
+                yield await(fn (): bool => $this->inbox->hasUnread());
+
+                $this->inbox->nextUnread();
+            }
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,8 +43,15 @@ abstract class TestCase extends BaseTestCase
 
         for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
             self::$workers[$i] = new Process(['php', __DIR__ . '/../vendor/bin/testbench', 'queue:work']);
-            self::$workers[$i]->disableOutput();
-            self::$workers[$i]->start();
+            if (! self::shouldStreamWorkerOutput()) {
+                self::$workers[$i]->disableOutput();
+                self::$workers[$i]->start();
+                continue;
+            }
+
+            self::$workers[$i]->start(static function (string $type, string $output) use ($i): void {
+                fwrite(STDERR, '[worker-' . $i . '][' . $type . '] ' . $output);
+            });
         }
     }
 
@@ -93,5 +100,12 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app)
     {
         return [\Workflow\Providers\WorkflowServiceProvider::class];
+    }
+
+    private static function shouldStreamWorkerOutput(): bool
+    {
+        $value = getenv('WORKFLOW_TEST_STREAM_WORKER_OUTPUT') ?: ($_ENV['WORKFLOW_TEST_STREAM_WORKER_OUTPUT'] ?? null);
+
+        return in_array($value, ['1', 'true', 'yes', 'on'], true);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,17 +29,7 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
-        $redisHost = getenv('REDIS_HOST') ?: ($_ENV['REDIS_HOST'] ?? null);
-        $redisPort = getenv('REDIS_PORT') ?: ($_ENV['REDIS_PORT'] ?? 6379);
-        if ($redisHost && class_exists(\Redis::class)) {
-            try {
-                $redis = new \Redis();
-                $redis->connect($redisHost, (int) $redisPort);
-                $redis->flushDB();
-            } catch (\Throwable $e) {
-                // Ignore if no redis
-            }
-        }
+        self::flushRedis();
 
         for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
             self::$workers[$i] = new Process(['php', __DIR__ . '/../vendor/bin/testbench', 'queue:work']);
@@ -53,6 +43,10 @@ abstract class TestCase extends BaseTestCase
         foreach (self::$workers as $worker) {
             $worker->stop();
         }
+
+        self::$workers = [];
+
+        self::flushRedis();
     }
 
     protected function setUp(): void
@@ -67,17 +61,7 @@ abstract class TestCase extends BaseTestCase
 
         Cache::flush();
 
-        $redisHost = getenv('REDIS_HOST') ?: ($_ENV['REDIS_HOST'] ?? null);
-        $redisPort = getenv('REDIS_PORT') ?: ($_ENV['REDIS_PORT'] ?? 6379);
-        if ($redisHost && class_exists(\Redis::class)) {
-            try {
-                $redis = new \Redis();
-                $redis->connect($redisHost, (int) $redisPort);
-                $redis->flushDB();
-            } catch (\Throwable $e) {
-                // Ignore if no redis
-            }
-        }
+        self::flushRedis();
     }
 
     protected function defineDatabaseMigrations()
@@ -93,5 +77,20 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app)
     {
         return [\Workflow\Providers\WorkflowServiceProvider::class];
+    }
+
+    private static function flushRedis(): void
+    {
+        $redisHost = getenv('REDIS_HOST') ?: ($_ENV['REDIS_HOST'] ?? null);
+        $redisPort = getenv('REDIS_PORT') ?: ($_ENV['REDIS_PORT'] ?? 6379);
+        if ($redisHost && class_exists(\Redis::class)) {
+            try {
+                $redis = new \Redis();
+                $redis->connect($redisHost, (int) $redisPort);
+                $redis->flushDB();
+            } catch (\Throwable $e) {
+                // Ignore if no redis
+            }
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,17 +43,8 @@ abstract class TestCase extends BaseTestCase
 
         for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
             self::$workers[$i] = new Process(['php', __DIR__ . '/../vendor/bin/testbench', 'queue:work']);
-            if (! self::shouldCaptureWorkerOutput()) {
-                self::$workers[$i]->disableOutput();
-                self::$workers[$i]->start();
-                continue;
-            }
-
-            file_put_contents(self::workerLogPath($i), '');
-
-            self::$workers[$i]->start(static function (string $type, string $output) use ($i): void {
-                file_put_contents(self::workerLogPath($i), $output, FILE_APPEND | LOCK_EX);
-            });
+            self::$workers[$i]->disableOutput();
+            self::$workers[$i]->start();
         }
     }
 
@@ -102,21 +93,5 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app)
     {
         return [\Workflow\Providers\WorkflowServiceProvider::class];
-    }
-
-    private static function shouldCaptureWorkerOutput(): bool
-    {
-        $value = getenv(
-            'WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT'
-        ) ?: ($_ENV['WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT'] ?? null);
-
-        return in_array($value, ['1', 'true', 'yes', 'on'], true);
-    }
-
-    private static function workerLogPath(int $worker): string
-    {
-        return dirname(
-            __DIR__
-        ) . '/vendor/orchestra/testbench-core/laravel/storage/logs/workflow-test-worker-' . $worker . '.log';
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,14 +43,16 @@ abstract class TestCase extends BaseTestCase
 
         for ($i = 0; $i < self::NUMBER_OF_WORKERS; $i++) {
             self::$workers[$i] = new Process(['php', __DIR__ . '/../vendor/bin/testbench', 'queue:work']);
-            if (! self::shouldStreamWorkerOutput()) {
+            if (! self::shouldCaptureWorkerOutput()) {
                 self::$workers[$i]->disableOutput();
                 self::$workers[$i]->start();
                 continue;
             }
 
+            file_put_contents(self::workerLogPath($i), '');
+
             self::$workers[$i]->start(static function (string $type, string $output) use ($i): void {
-                fwrite(STDERR, '[worker-' . $i . '][' . $type . '] ' . $output);
+                file_put_contents(self::workerLogPath($i), $output, FILE_APPEND | LOCK_EX);
             });
         }
     }
@@ -102,10 +104,19 @@ abstract class TestCase extends BaseTestCase
         return [\Workflow\Providers\WorkflowServiceProvider::class];
     }
 
-    private static function shouldStreamWorkerOutput(): bool
+    private static function shouldCaptureWorkerOutput(): bool
     {
-        $value = getenv('WORKFLOW_TEST_STREAM_WORKER_OUTPUT') ?: ($_ENV['WORKFLOW_TEST_STREAM_WORKER_OUTPUT'] ?? null);
+        $value = getenv(
+            'WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT'
+        ) ?: ($_ENV['WORKFLOW_TEST_CAPTURE_WORKER_OUTPUT'] ?? null);
 
         return in_array($value, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private static function workerLogPath(int $worker): string
+    {
+        return dirname(
+            __DIR__
+        ) . '/vendor/orchestra/testbench-core/laravel/storage/logs/workflow-test-worker-' . $worker . '.log';
     }
 }

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -162,6 +162,55 @@ final class ActivityStubTest extends TestCase
         $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
+    public function testSkipsMultipleStoredExceptionsForDifferentSourceClass(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign-1',
+                    'code' => 0,
+                    'sourceClass' => TestOtherActivity::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 1,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign-2',
+                    'code' => 0,
+                    'sourceClass' => TestOtherActivity::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 2,
+                'now' => WorkflowStub::now(),
+                'class' => TestActivity::class,
+                'result' => Serializer::serialize('test'),
+            ]);
+
+        ActivityStub::make(TestActivity::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertSame('test', $result);
+        $this->assertSame(3, WorkflowStub::getContext()->index);
+    }
+
     public function testDoesNotMarkProbeMatchedForForeignStoredException(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -162,6 +162,49 @@ final class ActivityStubTest extends TestCase
         $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
+    public function testDoesNotMarkProbeMatchedForForeignStoredException(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign',
+                    'code' => 0,
+                    'sourceClass' => TestOtherActivity::class,
+                ]),
+            ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+            'probeIndex' => 0,
+            'probeClass' => TestActivity::class,
+            'probeMatched' => false,
+        ]);
+
+        ActivityStub::make(TestActivity::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertFalse(WorkflowStub::probeMatched());
+        $this->assertSame(2, WorkflowStub::getContext()->index);
+    }
+
     public function testAll(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -7,9 +7,11 @@ namespace Tests\Unit;
 use Exception;
 use RuntimeException;
 use Tests\Fixtures\TestActivity;
+use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\ActivityStub;
+use Workflow\Exception as WorkflowException;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowPendingStatus;
@@ -121,6 +123,43 @@ final class ActivityStubTest extends TestCase
             ->then(static function ($value) use (&$result) {
                 $result = $value;
             });
+    }
+
+    public function testSkipsStoredExceptionForDifferentSourceClass(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign',
+                    'code' => 0,
+                    'sourceClass' => TestOtherActivity::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 1,
+                'now' => WorkflowStub::now(),
+                'class' => TestActivity::class,
+                'result' => Serializer::serialize('test'),
+            ]);
+
+        ActivityStub::make(TestActivity::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertSame('test', $result);
+        $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
     public function testAll(): void

--- a/tests/Unit/ActivityStubTest.php
+++ b/tests/Unit/ActivityStubTest.php
@@ -201,6 +201,7 @@ final class ActivityStubTest extends TestCase
             });
 
         $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertFalse(WorkflowStub::probeMatched());
         $this->assertSame(2, WorkflowStub::getContext()->index);
     }

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -131,6 +131,77 @@ final class ChildWorkflowStubTest extends TestCase
         $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
+    public function testMarksProbeMatchedForMatchingStoredException(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'matching child failure',
+                    'code' => 0,
+                ]),
+            ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+            'probeIndex' => 0,
+            'probeClass' => TestChildWorkflow::class,
+            'probeMatched' => false,
+        ]);
+
+        try {
+            ChildWorkflowStub::make(TestChildWorkflow::class);
+            $this->fail('Expected child exception to be thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame('matching child failure', $exception->getMessage());
+        }
+
+        $this->assertTrue(WorkflowStub::probeMatched());
+    }
+
+    public function testReturnsUnresolvedPromiseWhenProbingWithoutStoredChildWorkflow(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+            'probeIndex' => 0,
+            'probeClass' => TestChildWorkflow::class,
+            'probeMatched' => false,
+        ]);
+
+        ChildWorkflowStub::make(TestChildWorkflow::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+    }
+
     public function testDoesNotResumeRunningStartedChildWorkflow(): void
     {
         $childWorkflow = Mockery::mock();

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -242,6 +242,7 @@ final class ChildWorkflowStubTest extends TestCase
             });
 
         $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertSame(1, WorkflowStub::getContext()->index);
     }
 

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -172,6 +172,49 @@ final class ChildWorkflowStubTest extends TestCase
         $this->assertTrue(WorkflowStub::probeMatched());
     }
 
+    public function testDoesNotMarkProbeMatchedForForeignStoredException(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign child failure',
+                    'code' => 0,
+                    'sourceClass' => TestExceptionWorkflow::class,
+                ]),
+            ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+            'probeIndex' => 0,
+            'probeClass' => TestChildWorkflow::class,
+            'probeMatched' => false,
+        ]);
+
+        ChildWorkflowStub::make(TestChildWorkflow::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertFalse(WorkflowStub::probeMatched());
+        $this->assertSame(2, WorkflowStub::getContext()->index);
+    }
+
     public function testReturnsUnresolvedPromiseWhenProbingWithoutStoredChildWorkflow(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -131,6 +131,55 @@ final class ChildWorkflowStubTest extends TestCase
         $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
+    public function testSkipsMultipleStoredExceptionsForDifferentSourceClass(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign child 1',
+                    'code' => 0,
+                    'sourceClass' => TestExceptionWorkflow::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 1,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign child 2',
+                    'code' => 0,
+                    'sourceClass' => TestExceptionWorkflow::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 2,
+                'now' => WorkflowStub::now(),
+                'class' => TestChildWorkflow::class,
+                'result' => Serializer::serialize('test'),
+            ]);
+
+        ChildWorkflowStub::make(TestChildWorkflow::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertSame('test', $result);
+        $this->assertSame(3, WorkflowStub::getContext()->index);
+    }
+
     public function testMarksProbeMatchedForMatchingStoredException(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());

--- a/tests/Unit/ChildWorkflowStubTest.php
+++ b/tests/Unit/ChildWorkflowStubTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Exception;
 use Mockery;
 use Tests\Fixtures\TestChildWorkflow;
+use Tests\Fixtures\TestExceptionWorkflow;
 use Tests\Fixtures\TestParentWorkflow;
 use Tests\TestCase;
 use Workflow\ChildWorkflowStub;
+use Workflow\Exception as WorkflowException;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowPendingStatus;
@@ -89,6 +92,43 @@ final class ChildWorkflowStubTest extends TestCase
             });
 
         $this->assertNull($result);
+    }
+
+    public function testSkipsStoredExceptionForDifferentSourceClass(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestParentWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => WorkflowStub::now(),
+                'class' => WorkflowException::class,
+                'result' => Serializer::serialize([
+                    'class' => Exception::class,
+                    'message' => 'foreign child',
+                    'code' => 0,
+                    'sourceClass' => TestExceptionWorkflow::class,
+                ]),
+            ]);
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 1,
+                'now' => WorkflowStub::now(),
+                'class' => TestChildWorkflow::class,
+                'result' => Serializer::serialize('test'),
+            ]);
+
+        ChildWorkflowStub::make(TestChildWorkflow::class)
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertSame('test', $result);
+        $this->assertSame(2, WorkflowStub::getContext()->index);
     }
 
     public function testDoesNotResumeRunningStartedChildWorkflow(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Exception as BaseException;
+use InvalidArgumentException;
+use RuntimeException;
 use Tests\Fixtures\TestProbeBackToBackWorkflow;
 use Tests\Fixtures\TestProbeChildFailureWorkflow;
 use Tests\Fixtures\TestProbeParallelChildWorkflow;
@@ -21,7 +24,7 @@ final class ExceptionTest extends TestCase
 {
     public function testMiddleware(): void
     {
-        $exception = new Exception(0, now()->toDateTimeString(), new StoredWorkflow(), new \Exception(
+        $exception = new Exception(0, now()->toDateTimeString(), new StoredWorkflow(), new BaseException(
             'Test exception'
         ));
 
@@ -42,7 +45,7 @@ final class ExceptionTest extends TestCase
             'status' => WorkflowRunningStatus::$name,
         ]);
 
-        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, new \Exception('Test exception'));
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, new BaseException('Test exception'));
         $exception->handle();
 
         $this->assertSame(WorkflowRunningStatus::class, $workflow->status());
@@ -64,14 +67,14 @@ final class ExceptionTest extends TestCase
                     ->toDateTimeString(),
                 'class' => Exception::class,
                 'result' => Serializer::serialize([
-                    'class' => \Exception::class,
+                    'class' => BaseException::class,
                     'message' => 'child failed: child-1',
                     'code' => 0,
                 ]),
             ]);
 
         $exception = new Exception(1, now()->toDateTimeString(), $storedWorkflow, [
-            'class' => \Exception::class,
+            'class' => BaseException::class,
             'message' => 'child failed: child-2',
             'code' => 0,
         ], sourceClass: TestProbeChildFailureWorkflow::class);
@@ -97,14 +100,14 @@ final class ExceptionTest extends TestCase
                     ->toDateTimeString(),
                 'class' => Exception::class,
                 'result' => Serializer::serialize([
-                    'class' => \RuntimeException::class,
+                    'class' => RuntimeException::class,
                     'message' => 'first failure',
                     'code' => 0,
                 ]),
             ]);
 
         $exception = new Exception(1, now()->toDateTimeString(), $storedWorkflow, [
-            'class' => \InvalidArgumentException::class,
+            'class' => InvalidArgumentException::class,
             'message' => 'second failure',
             'code' => 0,
         ], sourceClass: TestProbeRetryActivity::class);

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -21,6 +21,7 @@ use Tests\Fixtures\TestSagaParallelActivityWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
+use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowRunningStatus;
@@ -34,7 +35,13 @@ final class ExceptionTest extends TestCase
             'Test exception'
         ));
 
-        $this->assertSame([], $exception->middleware());
+        $middleware = collect($exception->middleware())
+            ->values();
+
+        $this->assertCount(1, $middleware);
+        $this->assertSame(WithoutOverlappingMiddleware::class, $middleware[0]::class);
+        $this->assertSame(WithoutOverlappingMiddleware::WORKFLOW, $middleware[0]->type);
+        $this->assertSame(15, $middleware[0]->expiresAfter);
     }
 
     public function testExceptionWorkflowRunning(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -26,6 +26,7 @@ use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowRunningStatus;
+use Workflow\Workflow;
 use Workflow\WorkflowStub;
 
 final class ExceptionTest extends TestCase
@@ -119,7 +120,7 @@ final class ExceptionTest extends TestCase
         $job = Mockery::mock(JobContract::class);
         $job->shouldReceive('release')
             ->once()
-            ->with(0);
+            ->with(1);
 
         $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
             'class' => BaseException::class,
@@ -186,6 +187,54 @@ final class ExceptionTest extends TestCase
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($exception));
+    }
+
+    public function testProbeReplayShortCircuitsWhenWorkflowClassIsNotInstantiable(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->class = ExceptionTestAbstractWorkflow::class;
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'abstract workflow class',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
+
+        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($exception));
+    }
+
+    public function testProbeReplayShortCircuitsWhenWorkflowClassAutoloadThrows(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->class = 'Tests\\Fixtures\\ThrowingAutoloadWorkflow';
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'autoload failure',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
+
+        $autoload = static function (string $class): void {
+            if ($class === 'Tests\\Fixtures\\ThrowingAutoloadWorkflow') {
+                throw new RuntimeException('autoload exploded');
+            }
+        };
+
+        spl_autoload_register($autoload);
+
+        try {
+            $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+            $method->setAccessible(true);
+
+            $this->assertTrue($method->invoke($exception));
+        } finally {
+            spl_autoload_unregister($autoload);
+        }
     }
 
     public function testSkipsWriteWhenProbeDoesNotReachCandidateException(): void
@@ -299,4 +348,8 @@ final class ExceptionTest extends TestCase
 
         $this->assertFalse($storedWorkflow->fresh()->hasLogByIndex(2));
     }
+}
+
+abstract class ExceptionTestAbstractWorkflow extends Workflow
+{
 }

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -44,6 +44,7 @@ final class ExceptionTest extends TestCase
         $this->assertCount(1, $middleware);
         $this->assertSame(WithoutOverlappingMiddleware::class, $middleware[0]::class);
         $this->assertSame(WithoutOverlappingMiddleware::WORKFLOW, $middleware[0]->type);
+        $this->assertSame(1, $middleware[0]->releaseAfter);
         $this->assertSame(15, $middleware[0]->expiresAfter);
     }
 
@@ -265,6 +266,27 @@ final class ExceptionTest extends TestCase
         $method->invoke($exception);
 
         $this->assertTrue(TestProbeNowSignalWorkflow::$signalSawCarbonNow);
+    }
+
+    public function testProbeReplayPersistsWhenNowCannotBeParsed(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowRunningStatus::$name,
+        ]);
+
+        $exception = new Exception(0, 'not-a-timestamp', $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'bad now',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
+
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
+        $method->setAccessible(true);
+
+        $this->assertSame('persist', $method->invoke($exception));
     }
 
     public function testSkipsWriteWhenProbeDoesNotReachCandidateException(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -15,6 +15,7 @@ use stdClass;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestProbeBackToBackWorkflow;
 use Tests\Fixtures\TestProbeChildFailureWorkflow;
+use Tests\Fixtures\TestProbeNowSignalWorkflow;
 use Tests\Fixtures\TestProbeParallelChildWorkflow;
 use Tests\Fixtures\TestProbeRetryActivity;
 use Tests\Fixtures\TestSagaActivity;
@@ -235,6 +236,35 @@ final class ExceptionTest extends TestCase
         } finally {
             spl_autoload_unregister($autoload);
         }
+    }
+
+    public function testProbeReplayUsesCarbonNowBeforeWorkflowHandleResetsContext(): void
+    {
+        TestProbeNowSignalWorkflow::$signalSawCarbonNow = false;
+
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestProbeNowSignalWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowRunningStatus::$name,
+        ]);
+        $storedWorkflow->signals()
+            ->create([
+                'method' => 'recordNowType',
+                'arguments' => Serializer::serialize([]),
+            ]);
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'probe now type',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
+
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
+        $method->setAccessible(true);
+        $method->invoke($exception);
+
+        $this->assertTrue(TestProbeNowSignalWorkflow::$signalSawCarbonNow);
     }
 
     public function testSkipsWriteWhenProbeDoesNotReachCandidateException(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -147,10 +147,10 @@ final class ExceptionTest extends TestCase
             'code' => 0,
         ], connection: 'redis', queue: 'default');
 
-        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
         $method->setAccessible(true);
 
-        $this->assertTrue($method->invoke($exception));
+        $this->assertSame('persist', $method->invoke($exception));
     }
 
     public function testProbeReplayShortCircuitsWhenWorkflowClassDoesNotExist(): void
@@ -165,10 +165,10 @@ final class ExceptionTest extends TestCase
             'code' => 0,
         ], connection: 'redis', queue: 'default');
 
-        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
         $method->setAccessible(true);
 
-        $this->assertTrue($method->invoke($exception));
+        $this->assertSame('persist', $method->invoke($exception));
     }
 
     public function testProbeReplayShortCircuitsWhenWorkflowClassIsNotAWorkflow(): void
@@ -183,10 +183,10 @@ final class ExceptionTest extends TestCase
             'code' => 0,
         ], connection: 'redis', queue: 'default');
 
-        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
         $method->setAccessible(true);
 
-        $this->assertTrue($method->invoke($exception));
+        $this->assertSame('persist', $method->invoke($exception));
     }
 
     public function testProbeReplayShortCircuitsWhenWorkflowClassIsNotInstantiable(): void
@@ -201,10 +201,10 @@ final class ExceptionTest extends TestCase
             'code' => 0,
         ], connection: 'redis', queue: 'default');
 
-        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
         $method->setAccessible(true);
 
-        $this->assertTrue($method->invoke($exception));
+        $this->assertSame('persist', $method->invoke($exception));
     }
 
     public function testProbeReplayShortCircuitsWhenWorkflowClassAutoloadThrows(): void
@@ -228,10 +228,10 @@ final class ExceptionTest extends TestCase
         spl_autoload_register($autoload);
 
         try {
-            $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+            $method = new ReflectionMethod(Exception::class, 'probeReplayDecision');
             $method->setAccessible(true);
 
-            $this->assertTrue($method->invoke($exception));
+            $this->assertSame('persist', $method->invoke($exception));
         } finally {
             spl_autoload_unregister($autoload);
         }
@@ -268,6 +268,31 @@ final class ExceptionTest extends TestCase
 
         $this->assertFalse($storedWorkflow->hasLogByIndex(1));
         $this->assertSame(1, $storedWorkflow->logs()->count());
+    }
+
+    public function testRetriesWriteWhenProbeMatchesAfterEarlierPendingWork(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestProbeParallelChildWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowRunningStatus::$name,
+        ]);
+
+        $job = Mockery::mock(JobContract::class);
+        $job->shouldReceive('release')
+            ->once()
+            ->with(1);
+
+        $exception = new Exception(1, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'child failed: child-2',
+            'code' => 0,
+        ], sourceClass: TestProbeChildFailureWorkflow::class);
+        $exception->setJob($job);
+        $exception->handle();
+
+        $this->assertFalse($storedWorkflow->fresh()->hasLogByIndex(1));
     }
 
     public function testPersistsWriteWhenProbeReachesCandidateException(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -21,7 +21,6 @@ use Tests\Fixtures\TestSagaParallelActivityWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
-use Workflow\Middleware\WithoutOverlappingMiddleware;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowRunningStatus;
@@ -35,12 +34,7 @@ final class ExceptionTest extends TestCase
             'Test exception'
         ));
 
-        $middleware = collect($exception->middleware())
-            ->values();
-
-        $this->assertCount(1, $middleware);
-        $this->assertSame(WithoutOverlappingMiddleware::class, get_class($middleware[0]));
-        $this->assertSame(15, $middleware[0]->expiresAfter);
+        $this->assertSame([], $exception->middleware());
     }
 
     public function testExceptionWorkflowRunning(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -7,10 +7,13 @@ namespace Tests\Unit;
 use Exception as BaseException;
 use InvalidArgumentException;
 use RuntimeException;
+use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestProbeBackToBackWorkflow;
 use Tests\Fixtures\TestProbeChildFailureWorkflow;
 use Tests\Fixtures\TestProbeParallelChildWorkflow;
 use Tests\Fixtures\TestProbeRetryActivity;
+use Tests\Fixtures\TestSagaActivity;
+use Tests\Fixtures\TestSagaParallelActivityWorkflow;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
@@ -114,5 +117,46 @@ final class ExceptionTest extends TestCase
         $exception->handle();
 
         $this->assertTrue($storedWorkflow->fresh()->hasLogByIndex(1));
+    }
+
+    public function testSkipsWriteWhenProbeReachesDifferentActivityClassAtSameIndex(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestSagaParallelActivityWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowRunningStatus::$name,
+        ]);
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now()
+                    ->toDateTimeString(),
+                'class' => TestActivity::class,
+                'result' => Serializer::serialize('step complete'),
+            ]);
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 1,
+                'now' => now()
+                    ->toDateTimeString(),
+                'class' => Exception::class,
+                'result' => Serializer::serialize([
+                    'class' => RuntimeException::class,
+                    'message' => 'parallel failure',
+                    'code' => 0,
+                ]),
+            ]);
+
+        $exception = new Exception(2, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => RuntimeException::class,
+            'message' => 'another parallel failure',
+            'code' => 0,
+        ], sourceClass: TestSagaActivity::class);
+        $exception->handle();
+
+        $this->assertFalse($storedWorkflow->fresh()->hasLogByIndex(2));
     }
 }

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Exception as BaseException;
+use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
+use Mockery;
+use ReflectionMethod;
 use RuntimeException;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestProbeBackToBackWorkflow;
@@ -52,6 +56,98 @@ final class ExceptionTest extends TestCase
         $exception->handle();
 
         $this->assertSame(WorkflowRunningStatus::class, $workflow->status());
+    }
+
+    public function testHandleResumesWorkflowWhenLogAlreadyExists(): void
+    {
+        $lock = Mockery::mock();
+        $lock->shouldReceive('get')
+            ->once()
+            ->andReturn(true);
+        $lock->shouldReceive('release')
+            ->once();
+
+        Cache::shouldReceive('lock')
+            ->once()
+            ->with('laravel-workflow-exception:123', 15)
+            ->andReturn($lock);
+
+        $workflow = Mockery::mock();
+        $workflow->shouldReceive('resume')
+            ->once();
+
+        $storedWorkflow = Mockery::mock(StoredWorkflow::class)
+            ->makePartial();
+        $storedWorkflow->id = 123;
+        $storedWorkflow->shouldReceive('effectiveConnection')
+            ->andReturn(null);
+        $storedWorkflow->shouldReceive('effectiveQueue')
+            ->andReturn(null);
+        $storedWorkflow->shouldReceive('toWorkflow')
+            ->once()
+            ->andReturn($workflow);
+        $storedWorkflow->shouldReceive('hasLogByIndex')
+            ->once()
+            ->with(0)
+            ->andReturn(true);
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, new BaseException('existing log'));
+        $exception->handle();
+
+        $this->assertSame(123, $storedWorkflow->id);
+
+        Mockery::close();
+    }
+
+    public function testHandleReleasesWhenExceptionLockUnavailable(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+
+        $lock = Mockery::mock();
+        $lock->shouldReceive('get')
+            ->once()
+            ->andReturn(false);
+
+        Cache::shouldReceive('lock')
+            ->once()
+            ->with('laravel-workflow-exception:' . $storedWorkflow->id, 15)
+            ->andReturn($lock);
+
+        $job = Mockery::mock(JobContract::class);
+        $job->shouldReceive('release')
+            ->once()
+            ->with(0);
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'locked',
+            'code' => 0,
+        ]);
+        $exception->setJob($job);
+        $exception->handle();
+
+        $this->assertFalse($storedWorkflow->hasLogByIndex(0));
+
+        Mockery::close();
+    }
+
+    public function testProbeReplayShortCircuitsWhenWorkflowClassIsInvalid(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->class = '';
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'invalid workflow class',
+            'code' => 0,
+        ]);
+
+        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($exception));
     }
 
     public function testSkipsWriteWhenProbeDoesNotReachCandidateException(): void
@@ -116,7 +212,13 @@ final class ExceptionTest extends TestCase
         ], sourceClass: TestProbeRetryActivity::class);
         $exception->handle();
 
+        $log = $storedWorkflow->fresh()
+            ->logs()
+            ->firstWhere('index', 1);
+
+        $this->assertNotNull($log);
         $this->assertTrue($storedWorkflow->fresh()->hasLogByIndex(1));
+        $this->assertSame(TestProbeRetryActivity::class, Serializer::unserialize($log->result)['sourceClass']);
     }
 
     public function testSkipsWriteWhenProbeReachesDifferentActivityClassAtSameIndex(): void

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use Mockery;
 use ReflectionMethod;
 use RuntimeException;
+use stdClass;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestProbeBackToBackWorkflow;
 use Tests\Fixtures\TestProbeChildFailureWorkflow;
@@ -143,7 +144,43 @@ final class ExceptionTest extends TestCase
             'class' => BaseException::class,
             'message' => 'invalid workflow class',
             'code' => 0,
-        ]);
+        ], connection: 'redis', queue: 'default');
+
+        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($exception));
+    }
+
+    public function testProbeReplayShortCircuitsWhenWorkflowClassDoesNotExist(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->class = 'Tests\\Fixtures\\MissingWorkflowClass';
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'missing workflow class',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
+
+        $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($exception));
+    }
+
+    public function testProbeReplayShortCircuitsWhenWorkflowClassIsNotAWorkflow(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->class = stdClass::class;
+
+        $exception = new Exception(0, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => BaseException::class,
+            'message' => 'non workflow class',
+            'code' => 0,
+        ], connection: 'redis', queue: 'default');
 
         $method = new ReflectionMethod(Exception::class, 'shouldPersistAfterProbeReplay');
         $method->setAccessible(true);

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Tests\Fixtures\TestProbeBackToBackWorkflow;
+use Tests\Fixtures\TestProbeChildFailureWorkflow;
+use Tests\Fixtures\TestProbeParallelChildWorkflow;
+use Tests\Fixtures\TestProbeRetryActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
 use Workflow\Exception;
@@ -44,9 +48,9 @@ final class ExceptionTest extends TestCase
         $this->assertSame(WorkflowRunningStatus::class, $workflow->status());
     }
 
-    public function testSkipsWriteWhenSiblingExceptionLogExists(): void
+    public function testSkipsWriteWhenProbeDoesNotReachCandidateException(): void
     {
-        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestProbeParallelChildWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
         $storedWorkflow->update([
             'arguments' => Serializer::serialize([]),
@@ -61,19 +65,51 @@ final class ExceptionTest extends TestCase
                 'class' => Exception::class,
                 'result' => Serializer::serialize([
                     'class' => \Exception::class,
-                    'message' => 'first child failed',
+                    'message' => 'child failed: child-1',
                     'code' => 0,
                 ]),
             ]);
 
         $exception = new Exception(1, now()->toDateTimeString(), $storedWorkflow, [
             'class' => \Exception::class,
-            'message' => 'second child failed',
+            'message' => 'child failed: child-2',
             'code' => 0,
-        ]);
+        ], sourceClass: TestProbeChildFailureWorkflow::class);
         $exception->handle();
 
         $this->assertFalse($storedWorkflow->hasLogByIndex(1));
         $this->assertSame(1, $storedWorkflow->logs()->count());
+    }
+
+    public function testPersistsWriteWhenProbeReachesCandidateException(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestProbeBackToBackWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowRunningStatus::$name,
+        ]);
+
+        $storedWorkflow->logs()
+            ->create([
+                'index' => 0,
+                'now' => now()
+                    ->toDateTimeString(),
+                'class' => Exception::class,
+                'result' => Serializer::serialize([
+                    'class' => \RuntimeException::class,
+                    'message' => 'first failure',
+                    'code' => 0,
+                ]),
+            ]);
+
+        $exception = new Exception(1, now()->toDateTimeString(), $storedWorkflow, [
+            'class' => \InvalidArgumentException::class,
+            'message' => 'second failure',
+            'code' => 0,
+        ], sourceClass: TestProbeRetryActivity::class);
+        $exception->handle();
+
+        $this->assertTrue($storedWorkflow->fresh()->hasLogByIndex(1));
     }
 }

--- a/tests/Unit/Traits/AwaitsTest.php
+++ b/tests/Unit/Traits/AwaitsTest.php
@@ -128,6 +128,7 @@ final class AwaitsTest extends TestCase
 
         $this->assertFalse($conditionEvaluated);
         $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertSame(0, $workflow->logs()->count());
         $this->assertSame(1, WorkflowStub::getContext()->index);
     }

--- a/tests/Unit/Traits/AwaitsTest.php
+++ b/tests/Unit/Traits/AwaitsTest.php
@@ -102,6 +102,36 @@ final class AwaitsTest extends TestCase
         $this->assertFalse(Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
+    public function testDefersWhenProbing(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $conditionEvaluated = false;
+        $result = null;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+        ]);
+
+        WorkflowStub::await(static function () use (&$conditionEvaluated): bool {
+            $conditionEvaluated = true;
+
+            return true;
+        })
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertFalse($conditionEvaluated);
+        $this->assertNull($result);
+        $this->assertSame(0, $workflow->logs()->count());
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+    }
+
     public function testThrowsQueryExceptionWhenNotDuplicateKey(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());

--- a/tests/Unit/Traits/SideEffectsTest.php
+++ b/tests/Unit/Traits/SideEffectsTest.php
@@ -88,6 +88,36 @@ final class SideEffectsTest extends TestCase
         $this->assertSame('test', Serializer::unserialize($workflow->logs()->firstWhere('index', 0)->result));
     }
 
+    public function testDefersWhenProbing(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $callableEvaluated = false;
+        $result = null;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+        ]);
+
+        WorkflowStub::sideEffect(static function () use (&$callableEvaluated): string {
+            $callableEvaluated = true;
+
+            return 'test';
+        })
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertFalse($callableEvaluated);
+        $this->assertNull($result);
+        $this->assertSame(0, $workflow->logs()->count());
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+    }
+
     public function testThrowsQueryExceptionWhenNotDuplicateKey(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());

--- a/tests/Unit/Traits/SideEffectsTest.php
+++ b/tests/Unit/Traits/SideEffectsTest.php
@@ -114,6 +114,7 @@ final class SideEffectsTest extends TestCase
 
         $this->assertFalse($callableEvaluated);
         $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertSame(0, $workflow->logs()->count());
         $this->assertSame(1, WorkflowStub::getContext()->index);
     }

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -242,6 +242,38 @@ final class TimersTest extends TestCase
         ]);
     }
 
+    public function testTimerReturnsUnresolvedPromiseWhenProbingAndNoTimer(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+        ]);
+
+        WorkflowStub::timer('1 minute')
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+        $this->assertSame(0, $workflow->logs()->count());
+        $this->assertDatabaseMissing('workflow_timers', [
+            'stored_workflow_id' => $workflow->id(),
+            'index' => 0,
+        ]);
+    }
+
     public function testTimerCapsDelayForSqsDriver(): void
     {
         Bus::fake();

--- a/tests/Unit/Traits/TimersTest.php
+++ b/tests/Unit/Traits/TimersTest.php
@@ -267,11 +267,47 @@ final class TimersTest extends TestCase
 
         $this->assertNull($result);
         $this->assertSame(1, WorkflowStub::getContext()->index);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertSame(0, $workflow->logs()->count());
         $this->assertDatabaseMissing('workflow_timers', [
             'stored_workflow_id' => $workflow->id(),
             'index' => 0,
         ]);
+    }
+
+    public function testTimerMarksProbePendingBeforeMatchWhenStoredTimerHasNotElapsed(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+        $storedWorkflow->update([
+            'arguments' => Serializer::serialize([]),
+            'status' => WorkflowPendingStatus::$name,
+        ]);
+        $storedWorkflow->timers()
+            ->create([
+                'index' => 0,
+                'stop_at' => now()
+                    ->addMinute(),
+            ]);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+        ]);
+
+        WorkflowStub::timer('1 minute')
+            ->then(static function ($value) use (&$result) {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+        $this->assertSame(0, $workflow->logs()->count());
     }
 
     public function testTimerCapsDelayForSqsDriver(): void

--- a/tests/Unit/Traits/VersionsTest.php
+++ b/tests/Unit/Traits/VersionsTest.php
@@ -211,6 +211,7 @@ final class VersionsTest extends TestCase
             });
 
         $this->assertNull($result);
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         $this->assertSame(1, WorkflowStub::getContext()->index);
         $this->assertSame(0, $workflow->logs()->count());
     }

--- a/tests/Unit/Traits/VersionsTest.php
+++ b/tests/Unit/Traits/VersionsTest.php
@@ -191,6 +191,30 @@ final class VersionsTest extends TestCase
         Mockery::close();
     }
 
+    public function testReturnsUnresolvedPromiseWhenProbingWithoutStoredVersion(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $result = null;
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 0,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+        ]);
+
+        WorkflowStub::getVersion('test-change', WorkflowStub::DEFAULT_VERSION, 1)
+            ->then(static function ($value) use (&$result): void {
+                $result = $value;
+            });
+
+        $this->assertNull($result);
+        $this->assertSame(1, WorkflowStub::getContext()->index);
+        $this->assertSame(0, $workflow->logs()->count());
+    }
+
     public function testThrowsQueryExceptionWhenNotDuplicateKey(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());

--- a/tests/Unit/WorkflowFakerTest.php
+++ b/tests/Unit/WorkflowFakerTest.php
@@ -71,6 +71,25 @@ final class WorkflowFakerTest extends TestCase
         $this->assertSame($workflow->output(), 'workflow_activity_other_activity');
     }
 
+    public function testParentWorkflowWithCallableChildMock(): void
+    {
+        WorkflowStub::fake();
+
+        WorkflowStub::mock(TestActivity::class, 'activity');
+
+        WorkflowStub::mock(TestChildWorkflow::class, static function ($context) {
+            return 'other_activity';
+        });
+
+        $workflow = WorkflowStub::make(TestParentWorkflow::class);
+        $workflow->start();
+
+        WorkflowStub::assertDispatchedTimes(TestActivity::class, 1);
+        WorkflowStub::assertDispatchedTimes(TestChildWorkflow::class, 1);
+
+        $this->assertSame($workflow->output(), 'workflow_activity_other_activity');
+    }
+
     public function testConcurrentWorkflow(): void
     {
         WorkflowStub::fake();

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -8,6 +8,8 @@ use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
+use ReflectionProperty;
+use stdClass;
 use Tests\Fixtures\TestAwaitWorkflow;
 use Tests\Fixtures\TestBadConnectionWorkflow;
 use Tests\Fixtures\TestChatBotWorkflow;
@@ -229,6 +231,42 @@ final class WorkflowStubTest extends TestCase
 
         $this->assertSame('redis', WorkflowStub::connection());
         $this->assertSame('default', WorkflowStub::queue());
+    }
+
+    public function testProbeHelpers(): void
+    {
+        $contextProperty = new ReflectionProperty(WorkflowStub::class, 'context');
+        $contextProperty->setAccessible(true);
+        $previousContext = $contextProperty->getValue();
+        $contextProperty->setValue(null);
+
+        try {
+            $this->assertInstanceOf(stdClass::class, WorkflowStub::getContext());
+            $this->assertFalse(WorkflowStub::isProbing());
+            $this->assertNull(WorkflowStub::probeIndex());
+            $this->assertNull(WorkflowStub::probeClass());
+            $this->assertFalse(WorkflowStub::probeMatched());
+
+            WorkflowStub::markProbeMatched();
+
+            $this->assertFalse(WorkflowStub::probeMatched());
+
+            WorkflowStub::setContext([
+                'probing' => true,
+                'probeIndex' => 7,
+                'probeClass' => TestWorkflow::class,
+                'probeMatched' => false,
+            ]);
+
+            WorkflowStub::markProbeMatched();
+
+            $this->assertTrue(WorkflowStub::isProbing());
+            $this->assertSame(7, WorkflowStub::probeIndex());
+            $this->assertSame(TestWorkflow::class, WorkflowStub::probeClass());
+            $this->assertTrue(WorkflowStub::probeMatched());
+        } finally {
+            $contextProperty->setValue($previousContext);
+        }
     }
 
     public function testHandlesDuplicateLogInsertionProperly(): void

--- a/tests/Unit/WorkflowStubTest.php
+++ b/tests/Unit/WorkflowStubTest.php
@@ -246,24 +246,30 @@ final class WorkflowStubTest extends TestCase
             $this->assertNull(WorkflowStub::probeIndex());
             $this->assertNull(WorkflowStub::probeClass());
             $this->assertFalse(WorkflowStub::probeMatched());
+            $this->assertFalse(WorkflowStub::probePendingBeforeMatch());
 
             WorkflowStub::markProbeMatched();
+            WorkflowStub::markProbePendingBeforeMatch();
 
             $this->assertFalse(WorkflowStub::probeMatched());
+            $this->assertFalse(WorkflowStub::probePendingBeforeMatch());
 
             WorkflowStub::setContext([
                 'probing' => true,
                 'probeIndex' => 7,
                 'probeClass' => TestWorkflow::class,
                 'probeMatched' => false,
+                'probePendingBeforeMatch' => false,
             ]);
 
+            WorkflowStub::markProbePendingBeforeMatch();
             WorkflowStub::markProbeMatched();
 
             $this->assertTrue(WorkflowStub::isProbing());
             $this->assertSame(7, WorkflowStub::probeIndex());
             $this->assertSame(TestWorkflow::class, WorkflowStub::probeClass());
             $this->assertTrue(WorkflowStub::probeMatched());
+            $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
         } finally {
             $contextProperty->setValue($previousContext);
         }

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Mockery;
+use ReflectionMethod;
 use Tests\Fixtures\TestActivity;
 use Tests\Fixtures\TestChildWorkflow;
 use Tests\Fixtures\TestContinueAsNewWorkflow;
@@ -177,6 +178,43 @@ final class WorkflowTest extends TestCase
         $activity->handle();
 
         $this->assertSame(1, $storedWorkflow->logs()->count());
+    }
+
+    public function testSetContextPreservesProbePendingBeforeMatch(): void
+    {
+        $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
+        $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
+        $storedWorkflow->arguments = Serializer::serialize([]);
+        $storedWorkflow->save();
+
+        $workflow = new Workflow($storedWorkflow);
+
+        WorkflowStub::setContext([
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 3,
+            'now' => now(),
+            'replaying' => true,
+            'probing' => true,
+            'probeIndex' => 7,
+            'probeClass' => TestActivity::class,
+            'probeMatched' => true,
+            'probePendingBeforeMatch' => true,
+        ]);
+
+        $method = new ReflectionMethod(Workflow::class, 'setContext');
+        $method->setAccessible(true);
+        $method->invoke($workflow, [
+            'storedWorkflow' => $storedWorkflow,
+            'index' => 4,
+            'now' => now(),
+            'replaying' => true,
+        ]);
+
+        $this->assertTrue(WorkflowStub::isProbing());
+        $this->assertSame(7, WorkflowStub::probeIndex());
+        $this->assertSame(TestActivity::class, WorkflowStub::probeClass());
+        $this->assertTrue(WorkflowStub::probeMatched());
+        $this->assertTrue(WorkflowStub::probePendingBeforeMatch());
     }
 
     public function testParent(): void


### PR DESCRIPTION
## Summary
This change replaces the global "any prior `Workflow\\Exception` log" suppression with a replay probe.

When an exception job arrives for a missing log index, we now:
- append a synthetic in-memory exception log to the loaded workflow history
- replay the workflow in a `probing` mode that does not dispatch missing work or execute side effects
- persist the real exception log only if replay actually matches that exact exception on the active path

This preserves the child-exception propagation fix from `#348` while avoiding the later logging regression reported in `#372`.

## Root cause
`1.0.70` changed exception persistence from "one log per index" to "only the first exception log anywhere in the workflow". That deduped stale parallel sibling failures, but it also suppressed legitimate later exceptions after:
- signal-driven retries
- consecutive caught failures at new indexes

Heuristics like "previous log is an exception" or "same replay timestamp" were still too coarse, because real workflows can catch one exception and then legitimately hit another failure without any neutral log in between.

## What changed
- add a `probing` replay mode to `WorkflowStub` / `Workflow`
- prevent probing replays from dispatching missing activities, children, timers, side effects, or versions
- pass the failing child source class into `Workflow\\Exception` jobs
- only persist an exception log if the probing replay matches that exact `(index, class)` on the live path
- add regression coverage for:
  - signal-driven retries logging multiple sequential exceptions
  - back-to-back caught failures logging multiple sequential exceptions
  - parallel child failures still deduping to one parent exception log