### PR TITLE
Rename package to durable-workflow/workflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,11 @@
 {
-    "name": "laravel-workflow/laravel-workflow",
+    "name": "durable-workflow/workflow",
     "description": "Durable workflow engine that allows users to write long running persistent distributed workflows (orchestrations) in PHP powered by Laravel queues.",
     "type": "library",
     "license": "MIT",
+    "replace": {
+        "laravel-workflow/laravel-workflow": "self.version"
+    },
     "autoload": {
         "psr-4": {
             "Workflow\\": "src/"


### PR DESCRIPTION
## Summary
- Rename the Composer package from \`laravel-workflow/laravel-workflow\` to \`durable-workflow/workflow\`.
- Add a \`replace\` clause so the old name keeps resolving for existing consumers during the transition.
- PHP namespace (\`Workflow\\\`) is unchanged — decoupled from the package name.

## Follow-ups (out of scope)
- README badges / install snippets
- Packagist: submit new package, mark old one abandoned pointing to the new name
- Lockfile regeneration in downstream consumers (blocked on new name being published)

## Test plan
- [ ] \`composer validate\` passes
- [ ] Consumers using old name still resolve via \`replace\`
- [ ] Consumers using new name resolve from Packagist once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)