### PR TITLE
Rename package to durable-workflow/workflow (v2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,11 @@
 {
-    "name": "laravel-workflow/laravel-workflow",
+    "name": "durable-workflow/workflow",
     "description": "Durable workflow engine that allows users to write long running persistent distributed workflows (orchestrations) in PHP powered by Laravel queues.",
     "type": "library",
     "license": "MIT",
+    "replace": {
+        "laravel-workflow/laravel-workflow": "self.version"
+    },
     "autoload": {
         "psr-4": {
             "Workflow\\": "src/"


### PR DESCRIPTION
## Summary
- Rename the Composer package from \`laravel-workflow/laravel-workflow\` to \`durable-workflow/workflow\` on the v2 branch.
- Add a \`replace\` clause so the old name keeps resolving for existing consumers.
- PHP namespace (\`Workflow\\\`) is unchanged.

Companion to #378 (same rename on master).

## Follow-ups (out of scope)
- README/docs updates
- Packagist submit/abandon
- Lockfile regeneration in consumers (after publish)

## Test plan
- [ ] \`composer validate\` passes
- [ ] server/sample-app can resolve workflow under the new name after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)